### PR TITLE
make GoogleIDFASupport Optional with subspec

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,17 @@
 PODS:
-  - Analytics (3.0.0)
+  - Analytics (3.0.7)
   - Expecta (1.0.5)
   - GoogleAnalytics (3.14.0)
   - GoogleIDFASupport (3.14.0)
-  - Segment-GoogleAnalytics (1.0.0-alpha):
+  - Segment-GoogleAnalytics (1.0.1):
+    - Analytics (~> 3.0.0)
+    - GoogleAnalytics (~> 3.14)
+    - Segment-GoogleAnalytics/Core (= 1.0.1)
+    - Segment-GoogleAnalytics/GoogleIDFASupport (= 1.0.1)
+  - Segment-GoogleAnalytics/Core (1.0.1):
+    - Analytics (~> 3.0.0)
+    - GoogleAnalytics (~> 3.14)
+  - Segment-GoogleAnalytics/GoogleIDFASupport (1.0.1):
     - Analytics (~> 3.0.0)
     - GoogleAnalytics (~> 3.14)
     - GoogleIDFASupport (~> 3.14)
@@ -19,11 +27,11 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Analytics: 3ebd9eee7aa18bbf7d6418f2290b0bbf694144d5
+  Analytics: b342fb4f43fa4f97ca6f4358b44d3295217ba294
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   GoogleAnalytics: 9be1afdb8deeac4bb5f13ca7f7d3b9db2a1f43dc
   GoogleIDFASupport: aaf8c10bd429abb1c15349d5252244f5eda8ead1
-  Segment-GoogleAnalytics: 5253ee2c8e96f1576fdde6f63dffff24068dafdd
+  Segment-GoogleAnalytics: b14a2d28b82477dee4fd28fb11650d50522715b9
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 
 COCOAPODS: 0.39.0

--- a/Example/Pods/Analytics/Pod/Classes/Integrations/SEGIdentifyPayload.h
+++ b/Example/Pods/Analytics/Pod/Classes/Integrations/SEGIdentifyPayload.h
@@ -6,9 +6,12 @@
 
 @property (nonatomic, readonly) NSString *userId;
 
+@property (nonatomic, readonly) NSString *anonymousId;
+
 @property (nonatomic, readonly) NSDictionary *traits;
 
 - (instancetype)initWithUserId:(NSString *)userId
+                   anonymousId:(NSString *)anonymousId
                         traits:(NSDictionary *)traits
                        context:(NSDictionary *)context
                   integrations:(NSDictionary *)integrations;

--- a/Example/Pods/Analytics/Pod/Classes/Integrations/SEGIdentifyPayload.m
+++ b/Example/Pods/Analytics/Pod/Classes/Integrations/SEGIdentifyPayload.m
@@ -4,12 +4,14 @@
 @implementation SEGIdentifyPayload
 
 - (instancetype)initWithUserId:(NSString *)userId
+                   anonymousId:(NSString *)anonymousId
                         traits:(NSDictionary *)traits
                        context:(NSDictionary *)context
                   integrations:(NSDictionary *)integrations
 {
     if (self = [super initWithContext:context integrations:integrations]) {
         _userId = [userId copy];
+        _anonymousId = [anonymousId copy];
         _traits = [traits copy];
     }
     return self;

--- a/Example/Pods/Analytics/Pod/Classes/Internal/SEGAnalyticsUtils.h
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/SEGAnalyticsUtils.h
@@ -3,9 +3,6 @@
 
 #import <Foundation/Foundation.h>
 
-#define SEGStringize_helper(x) #x
-#define SEGStringize(x) @SEGStringize_helper(x)
-
 NSURL *SEGAnalyticsURLForFilename(NSString *filename);
 
 // Date Utils

--- a/Example/Pods/Analytics/Pod/Classes/Internal/SEGLocation.h
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/SEGLocation.h
@@ -23,4 +23,6 @@
 @property (nonatomic, copy, readonly) NSDictionary *addressDictionary;
 @property (nonatomic, assign, readonly) BOOL hasKnownLocation;
 
+- (void)startUpdatingLocation;
+
 @end

--- a/Example/Pods/Analytics/Pod/Classes/Internal/SEGLocation.m
+++ b/Example/Pods/Analytics/Pod/Classes/Internal/SEGLocation.m
@@ -26,6 +26,8 @@
         return result;                                                                             \
     }
 
+#define LOCATION_AGE 300.0 // 5 minutes
+
 
 @interface SEGLocation () <CLLocationManagerDelegate>
 
@@ -45,10 +47,12 @@
 
     if (self = [super init]) {
         self.geocoder = [[CLGeocoder alloc] init];
-        self.locationManager = [[CLLocationManager alloc] init];
-        self.locationManager.delegate = self;
-        [self.locationManager startUpdatingLocation];
         self.syncQueue = dispatch_queue_create("io.segment.location.syncQueue", NULL);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            self.locationManager = [[CLLocationManager alloc] init];
+            self.locationManager.delegate = self;
+            [self.locationManager startUpdatingLocation];
+        });
     }
     return self;
 }
@@ -61,6 +65,20 @@ LOCATION_STRING_PROPERTY(street, thoroughfare);
 LOCATION_NUMBER_PROPERTY(latitude, location.coordinate.latitude);
 LOCATION_NUMBER_PROPERTY(longitude, location.coordinate.longitude);
 LOCATION_NUMBER_PROPERTY(speed, location.speed);
+
+- (void)startUpdatingLocation
+{
+    if (self.locationManager && self.currentPlacemark) {
+        CLLocation *location = self.currentPlacemark.location;
+        NSDate *eventDate = location.timestamp;
+        NSTimeInterval howRecent = [eventDate timeIntervalSinceNow];
+        if (fabs(howRecent) > LOCATION_AGE) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self.locationManager startUpdatingLocation];
+            });
+        }
+    }
+}
 
 - (BOOL)hasKnownLocation
 {
@@ -87,14 +105,26 @@ LOCATION_NUMBER_PROPERTY(speed, location.speed);
 {
     if (!locations.count) return;
 
-    __weak typeof(self) weakSelf = self;
-    [self.geocoder reverseGeocodeLocation:locations.firstObject
-                        completionHandler:^(NSArray *placemarks, NSError *error) {
-                            __strong typeof(weakSelf) strongSelf = weakSelf;
-                            dispatch_sync(strongSelf.syncQueue, ^{
-                                strongSelf.currentPlacemark = placemarks.firstObject;
-                            });
-                        }];
+    //https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/LocationAwarenessPG/CoreLocation/CoreLocation.html
+    CLLocation *location = [locations lastObject];
+    NSDate *eventDate = location.timestamp;
+    NSTimeInterval howRecent = [eventDate timeIntervalSinceNow];
+    if (fabs(howRecent) < LOCATION_AGE) {
+        // If the event is recent, do something with it.
+        __weak typeof(self) weakSelf = self;
+        [self.geocoder reverseGeocodeLocation:location
+                            completionHandler:^(NSArray *placemarks, NSError *error) {
+                                if (error) {
+                                    SEGLog(@"error: %@", error);
+                                } else if (placemarks.count) {
+                                    __strong typeof(weakSelf) strongSelf = weakSelf;
+                                    dispatch_sync(strongSelf.syncQueue, ^{
+                                        strongSelf.currentPlacemark = placemarks.firstObject;
+                                        [strongSelf.locationManager stopUpdatingLocation];
+                                    });
+                                }
+                            }];
+    }
 }
 
 - (void)locationManager:(CLLocationManager *)manager didFailWithError:(NSError *)error

--- a/Example/Pods/Analytics/Pod/Classes/SEGAnalytics.h
+++ b/Example/Pods/Analytics/Pod/Classes/SEGAnalytics.h
@@ -56,6 +56,13 @@
 @property (nonatomic, strong, readonly) SEGAnalyticsConfiguration *configuration;
 
 /**
+ * Setup this analytics client instance.
+ *
+ * @param configuration The configuration used to setup the client.
+ */
+- (instancetype)initWithConfiguration:(SEGAnalyticsConfiguration *)configuration;
+
+/**
  * Setup the analytics client.
  *
  * @param configuration The configuration used to setup the client.
@@ -87,6 +94,8 @@
  generate the UUID and Apple's policies on IDs, see https://segment.io/libraries/ios#ids
 
  @param traits        A dictionary of traits you know about the user. Things like: email, name, plan, etc.
+
+ @param options       A dictionary of options, such as the `@"anonymousId"` key. If no anonymous ID is specified one will be generated for you.
 
  @discussion
  When you learn more about who your user is, you can record that information with identify.
@@ -246,7 +255,7 @@
 @interface SEGAnalytics (Deprecated)
 
 + (void)initializeWithWriteKey:(NSString *)writeKey __attribute__((deprecated("Use +setupWithConfiguration: instead")));
-- (id)initWithWriteKey:(NSString *)writeKey __attribute__((deprecated("Use -initWithConfiguration: instead")));
+- (instancetype)initWithWriteKey:(NSString *)writeKey __attribute__((deprecated("Use -initWithConfiguration: instead")));
 - (void)registerPushDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registerForRemoteNotificationsWithDeviceToken: instead")));
 - (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken __attribute__((deprecated("Use -registeredForRemoteNotificationsWithDeviceToken: instead")));
 - (void)registerForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken options:(NSDictionary *)options __attribute__((deprecated("Use -registeredForRemoteNotificationsWithDeviceToken: instead")));

--- a/Example/Pods/Analytics/Pod/Classes/SEGAnalytics.m
+++ b/Example/Pods/Analytics/Pod/Classes/SEGAnalytics.m
@@ -30,7 +30,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
     return [[SEGAnalyticsConfiguration alloc] initWithWriteKey:writeKey];
 }
 
-- (id)initWithWriteKey:(NSString *)writeKey
+- (instancetype)initWithWriteKey:(NSString *)writeKey
 {
     if (self = [self init]) {
         self.writeKey = writeKey;
@@ -74,6 +74,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
 @property (nonatomic, strong) NSArray *factories;
 @property (nonatomic, strong) NSMutableDictionary *integrations;
 @property (nonatomic, strong) NSMutableDictionary *registeredIntegrations;
+@property (nonatomic) volatile BOOL initialized;
 
 @end
 
@@ -90,7 +91,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
     });
 }
 
-- (id)initWithConfiguration:(SEGAnalyticsConfiguration *)configuration
+- (instancetype)initWithConfiguration:(SEGAnalyticsConfiguration *)configuration
 {
     NSCParameterAssert(configuration != nil);
 
@@ -101,6 +102,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
         self.messageQueue = [[NSMutableArray alloc] init];
         self.factories = [configuration.factories copy];
         self.integrations = [NSMutableDictionary dictionaryWithCapacity:self.factories.count];
+        self.registeredIntegrations = [NSMutableDictionary dictionaryWithCapacity:self.factories.count];
         self.configuration = configuration;
 
         // Update settings on each integration immediately
@@ -156,8 +158,9 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
                             };
     });
     SEL selector = NSSelectorFromString(selectorMapping[note.name]);
-    if (selector)
-        [self callIntegrationsWithSelector:selector arguments:nil options:nil];
+    if (selector) {
+        [self callIntegrationsWithSelector:selector arguments:nil options:nil sync:true];
+    }
 }
 
 #pragma mark - Public API
@@ -186,13 +189,15 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
     NSCParameterAssert(userId.length > 0 || traits.count > 0);
 
     SEGIdentifyPayload *payload = [[SEGIdentifyPayload alloc] initWithUserId:userId
+                                                                 anonymousId:[options objectForKey:@"anonymousId"]
                                                                       traits:SEGCoerceDictionary(traits)
                                                                      context:SEGCoerceDictionary([options objectForKey:@"context"])
                                                                 integrations:[options objectForKey:@"integrations"]];
 
     [self callIntegrationsWithSelector:NSSelectorFromString(@"identify:")
                              arguments:@[ payload ]
-                               options:options];
+                               options:options
+                                  sync:false];
 }
 
 #pragma mark - Track
@@ -218,7 +223,8 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
 
     [self callIntegrationsWithSelector:NSSelectorFromString(@"track:")
                              arguments:@[ payload ]
-                               options:options];
+                               options:options
+                                  sync:false];
 }
 
 #pragma mark - Screen
@@ -242,10 +248,10 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
                                                                context:SEGCoerceDictionary([options objectForKey:@"context"])
                                                           integrations:[options objectForKey:@"integrations"]];
 
-
     [self callIntegrationsWithSelector:NSSelectorFromString(@"screen:")
                              arguments:@[ payload ]
-                               options:options];
+                               options:options
+                                  sync:false];
 }
 
 #pragma mark - Group
@@ -269,7 +275,8 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
 
     [self callIntegrationsWithSelector:NSSelectorFromString(@"group:")
                              arguments:@[ payload ]
-                               options:options];
+                               options:options
+                                  sync:false];
 }
 
 #pragma mark - Alias
@@ -287,39 +294,40 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
 
     [self callIntegrationsWithSelector:NSSelectorFromString(@"alias:")
                              arguments:@[ payload ]
-                               options:options];
+                               options:options
+                                  sync:false];
 }
 
 - (void)receivedRemoteNotification:(NSDictionary *)userInfo
 {
-    [self callIntegrationsWithSelector:_cmd arguments:@[ userInfo ] options:nil];
+    [self callIntegrationsWithSelector:_cmd arguments:@[ userInfo ] options:nil sync:true];
 }
 
 - (void)failedToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
-    [self callIntegrationsWithSelector:_cmd arguments:@[ error ] options:nil];
+    [self callIntegrationsWithSelector:_cmd arguments:@[ error ] options:nil sync:true];
 }
 
 - (void)registeredForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
     NSParameterAssert(deviceToken != nil);
 
-    [self callIntegrationsWithSelector:_cmd arguments:@[ deviceToken ] options:nil];
+    [self callIntegrationsWithSelector:_cmd arguments:@[ deviceToken ] options:nil sync:true];
 }
 
 - (void)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo
 {
-    [self callIntegrationsWithSelector:_cmd arguments:@[ identifier, userInfo ] options:nil];
+    [self callIntegrationsWithSelector:_cmd arguments:@[ identifier, userInfo ] options:nil sync:true];
 }
 
 - (void)reset
 {
-    [self callIntegrationsWithSelector:_cmd arguments:nil options:nil];
+    [self callIntegrationsWithSelector:_cmd arguments:nil options:nil sync:false];
 }
 
 - (void)flush
 {
-    [self callIntegrationsWithSelector:_cmd arguments:nil options:nil];
+    [self callIntegrationsWithSelector:_cmd arguments:nil options:nil sync:false];
 }
 
 - (void)enable
@@ -376,6 +384,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
 
     seg_dispatch_specific_async(_serialQueue, ^{
         [self flushMessageQueue];
+        self.initialized = true;
     });
 }
 
@@ -419,7 +428,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
 
 + (NSString *)version
 {
-    return @"3.0.0";
+    return @"3.0.7";
 }
 
 #pragma mark - Private
@@ -457,12 +466,14 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
     if (!_enabled)
         return;
 
-    if (self.integrations.count == 0)
-        SEGLog(@"Trying to send event, but no integrations found.");
-
-    [self.integrations enumerateKeysAndObjectsUsingBlock:^(NSString *key, id<SEGIntegration> integration, BOOL *stop) {
-        [self invokeIntegration:integration key:key selector:selector arguments:arguments options:options];
-    }];
+    // If the event has opted in for syncrhonous delivery, this may be called on any thread.
+    // Only allow one to be delivered at a time.
+    @synchronized(self)
+    {
+        [self.integrations enumerateKeysAndObjectsUsingBlock:^(NSString *key, id<SEGIntegration> integration, BOOL *stop) {
+            [self invokeIntegration:integration key:key selector:selector arguments:arguments options:options];
+        }];
+    }
 }
 
 - (void)invokeIntegration:(id<SEGIntegration>)integration key:(NSString *)key selector:(SEL)selector arguments:(NSArray *)arguments options:(NSDictionary *)options
@@ -522,16 +533,19 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
     }
 }
 
-- (void)callIntegrationsWithSelector:(SEL)selector arguments:(NSArray *)arguments options:(NSDictionary *)options
+- (void)callIntegrationsWithSelector:(SEL)selector arguments:(NSArray *)arguments options:(NSDictionary *)options sync:(BOOL)sync
 {
+    if (sync && self.initialized) {
+        [self forwardSelector:selector arguments:arguments options:options];
+        return;
+    }
+
     seg_dispatch_specific_async(_serialQueue, ^{
-        if (self.cachedSettings.count == 0 || self.settingsRequest != nil) {
-            // No cached settings, queue the API call
-            [self queueSelector:selector arguments:arguments options:options];
-        } else {
-            // Settings cached, flush message queue & new API call
+        if (self.initialized) {
             [self flushMessageQueue];
             [self forwardSelector:selector arguments:arguments options:options];
+        } else {
+            [self queueSelector:selector arguments:arguments options:options];
         }
     });
 }
@@ -559,7 +573,7 @@ NSString *SEGAnalyticsIntegrationDidStart = @"io.segment.analytics.integration.d
     [self setupWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey]];
 }
 
-- (id)initWithWriteKey:(NSString *)writeKey
+- (instancetype)initWithWriteKey:(NSString *)writeKey
 {
     return [self initWithConfiguration:[SEGAnalyticsConfiguration configurationWithWriteKey:writeKey]];
 }

--- a/Example/Pods/Local Podspecs/Segment-GoogleAnalytics.podspec.json
+++ b/Example/Pods/Local Podspecs/Segment-GoogleAnalytics.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Segment-GoogleAnalytics",
-  "version": "1.0.0-alpha",
+  "version": "1.0.1",
   "summary": "Google Analytics Integration for Segment's analytics-ios library.",
   "description": "Analytics for iOS provides a single API that lets you\nintegrate with over 100s of tools.\n\nThis is the Google Analytics integration for the iOS library.",
   "homepage": "http://segment.com/",
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/segment-integrations/analytics-ios-integration-google-analytics.git",
-    "tag": "1.0.0-alpha"
+    "tag": "1.0.1"
   },
   "social_media_url": "https://twitter.com/segment",
   "platforms": {
@@ -26,9 +26,19 @@
     ],
     "GoogleAnalytics": [
       "~> 3.14"
-    ],
-    "GoogleIDFASupport": [
-      "~> 3.14"
     ]
-  }
+  },
+  "subspecs": [
+    {
+      "name": "GoogleIDFASupport",
+      "dependencies": {
+        "GoogleIDFASupport": [
+          "~> 3.14"
+        ]
+      }
+    },
+    {
+      "name": "Core"
+    }
+  ]
 }

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,9 +1,17 @@
 PODS:
-  - Analytics (3.0.0)
+  - Analytics (3.0.7)
   - Expecta (1.0.5)
   - GoogleAnalytics (3.14.0)
   - GoogleIDFASupport (3.14.0)
-  - Segment-GoogleAnalytics (1.0.0-alpha):
+  - Segment-GoogleAnalytics (1.0.1):
+    - Analytics (~> 3.0.0)
+    - GoogleAnalytics (~> 3.14)
+    - Segment-GoogleAnalytics/Core (= 1.0.1)
+    - Segment-GoogleAnalytics/GoogleIDFASupport (= 1.0.1)
+  - Segment-GoogleAnalytics/Core (1.0.1):
+    - Analytics (~> 3.0.0)
+    - GoogleAnalytics (~> 3.14)
+  - Segment-GoogleAnalytics/GoogleIDFASupport (1.0.1):
     - Analytics (~> 3.0.0)
     - GoogleAnalytics (~> 3.14)
     - GoogleIDFASupport (~> 3.14)
@@ -19,11 +27,11 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Analytics: 3ebd9eee7aa18bbf7d6418f2290b0bbf694144d5
+  Analytics: b342fb4f43fa4f97ca6f4358b44d3295217ba294
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   GoogleAnalytics: 9be1afdb8deeac4bb5f13ca7f7d3b9db2a1f43dc
   GoogleIDFASupport: aaf8c10bd429abb1c15349d5252244f5eda8ead1
-  Segment-GoogleAnalytics: 5253ee2c8e96f1576fdde6f63dffff24068dafdd
+  Segment-GoogleAnalytics: b14a2d28b82477dee4fd28fb11650d50522715b9
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 
 COCOAPODS: 0.39.0

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -1,1569 +1,6185 @@
-// !$*UTF8*$!
-{
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXBuildFile section */
-		021C50274FF43A6F07E119D572C3ACB6 /* EXPMatchers+beginWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 22FAD7D819C780BD3941E8361C9DE50E /* EXPMatchers+beginWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		02C7E3EC1E1DFDD7046BD26A67E92686 /* EXPMatchers+contain.h in Headers */ = {isa = PBXBuildFile; fileRef = 76FDA2EF06A82D029BE55F779402A351 /* EXPMatchers+contain.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		02FA0FA148C2B4F13646BCD671C1DC0D /* SEGTrackPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = D99400BFB9A624D8E051FED7A1BDF315 /* SEGTrackPayload.m */; };
-		07282695806D1DFBF187BFA004D80641 /* EXPMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = DE73CB6561F92F5CB79F28F7A4303749 /* EXPMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		081F2104425CDCB0915354E2FBD7E24E /* ExpectaObject.h in Headers */ = {isa = PBXBuildFile; fileRef = E128AD4B837926B3A5A036D8E8DFECAD /* ExpectaObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0EBFCC5B0D8267DB953A68498EC7D758 /* SEGAliasPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = AA87D29C4C4D9CB70A5BB9010C93E406 /* SEGAliasPayload.m */; };
-		104AFE24D01F1C4495926B40B53C5945 /* EXPExpect.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D61BFA15E780468CFF692FA8FFE5AFE /* EXPExpect.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		10640AF349457B2280632CECCCA5FE7C /* SEGScreenPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A5D0FD313A4B5E5A78C8A34A9B71607 /* SEGScreenPayload.m */; };
-		118288E4B5564DBB3FCFD7D568BA34F9 /* SPTExampleGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 6807539CEC31F5EB61DC3B93ADD174C7 /* SPTExampleGroup.m */; };
-		11CF0C44A36897A963C15B74C2AEC415 /* ExpectaObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 90652227DA6C2B4C6C8E843F2F8BAC21 /* ExpectaObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		14C609D8F203FD45194E93997EFF744E /* EXPMatchers+beSubclassOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A2147C8C8E0A818D9BC42DC2F23709B /* EXPMatchers+beSubclassOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		187F46423F8CC699E4EC5B013DADF043 /* XCTestCase+Specta.m in Sources */ = {isa = PBXBuildFile; fileRef = AAAFAFFB150A80628C686DDD8D642B9D /* XCTestCase+Specta.m */; };
-		1FA53FB61D99D37B11CF3D7568F1FAA2 /* Pods-Segment-GoogleAnalytics_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 98AF2EF29263F6E5F2917A01134D91A1 /* Pods-Segment-GoogleAnalytics_Example-dummy.m */; };
-		2239B5E63C5D2C1323D66F489F075C42 /* EXPMatchers+match.m in Sources */ = {isa = PBXBuildFile; fileRef = FF44A189D47E0B1CB7FA13DE72A685BB /* EXPMatchers+match.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		237FB063FB365119546C7B5006224F3B /* EXPMatchers+haveCountOf.h in Headers */ = {isa = PBXBuildFile; fileRef = FAE4AA155A2514A44DCF02CDE86885CF /* EXPMatchers+haveCountOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		23C308732876898CC780DC4FD8A09F4C /* SEGGoogleAnalyticsIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 1090ADEE4E406645BC0603EF794F19AE /* SEGGoogleAnalyticsIntegration.m */; };
-		25BBDA674BE9447D354412C79BF4B16C /* SEGIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = C6B2685864B008D5854B7554B05FE815 /* SEGIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		26FDD94D57A937677D2A42E53E7DBD7A /* SEGSegmentIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 3ABC5E4B4982D08ED7380A4C08E3418C /* SEGSegmentIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2945FAA75C956DD6A541EB51E42E6899 /* EXPMatchers+conformTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D88ACEFC22E13FCF6F27A591CCC1D53 /* EXPMatchers+conformTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2A17721E4A81DB608CA6D4FB6F0ADAFB /* EXPExpect.h in Headers */ = {isa = PBXBuildFile; fileRef = EDB92F0DECBE15130358426D5213D6C8 /* EXPExpect.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2CDDCDCA361D583C58B28EF022F8387E /* XCTestCase+Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = 27B1B54BB2BA7B78455DCEB2FEF70BC6 /* XCTestCase+Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2D881B10160E6AA5B265F69CA2F53159 /* Specta.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C1E9D81E228F9B07251DEEB275F4744 /* Specta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2F824EA28F819F2E4A9E6D31E14D0603 /* SEGAnalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = CFAE41FD7F6F5C7D8E508C03208FFF59 /* SEGAnalytics.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		2F9D3747596E4E074C3B776949091047 /* EXPMatchers+beInstanceOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 90552A900C20BA732E285A6C8CDB4660 /* EXPMatchers+beInstanceOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		339A0C1BFF72397A705959E03877DDDB /* EXPMatchers+postNotification.h in Headers */ = {isa = PBXBuildFile; fileRef = 8DC6005FC38AC1939F82F6C1FB9A2E36 /* EXPMatchers+postNotification.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		341D7536159B52F41598F730CC45D548 /* EXPFloatTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = 56BBCF71F950D6191CD6B1B91A85FA82 /* EXPFloatTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3A013F13122CDB8EE962F8CB7C6FCC8E /* EXPDoubleTuple.h in Headers */ = {isa = PBXBuildFile; fileRef = B4B89A8180E266D6FD109356EBE762DA /* EXPDoubleTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3CF85CEBEA5339235C29E19B55D944ED /* SEGSegmentIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 7669417A2998C97CD154ABD987C5334E /* SEGSegmentIntegration.m */; };
-		3D508F6B13170EC5036ECEEECB475BA4 /* SPTSharedExampleGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 3756FB16CD0261AA42611CD5D01B88C7 /* SPTSharedExampleGroups.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3E463E2B6917D9AA08A03BA8A8E74A18 /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = C9E85A65EFBEA8CB9F441C68B3E492C1 /* EXPMatchers+beGreaterThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		40F505E69B8595361C2A7528DDA222B6 /* EXPUnsupportedObject.m in Sources */ = {isa = PBXBuildFile; fileRef = 66A04F37AA8446E5F76E605B220607FA /* EXPUnsupportedObject.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		41D47B37FDEA46945606C39C44042D8C /* SEGLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = D1CB69C27633FCC3576F1778EFC09B7D /* SEGLocation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4231743B6C143BDB4A5FBB032E6D3799 /* EXPUnsupportedObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 869F6CDA9DFD53454C106CBA668F580E /* EXPUnsupportedObject.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		430CE433DB59FE090A8CC6AFCFA43337 /* EXPMatchers+equal.h in Headers */ = {isa = PBXBuildFile; fileRef = 90A6E1569ECE25A96D932D7CB0456A00 /* EXPMatchers+equal.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		43659A5034D2F6C8510DDC52EFD7B7CA /* SPTExampleGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 56F3B4B2BD22271258A1CB037C17CF99 /* SPTExampleGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4383E0DB1B07B9EB3155EF5D5F27C7BA /* ExpectaSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = C258607F1A902F6E3358877275B1C45D /* ExpectaSupport.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		43A1104CA0C628C2F693902EADA32B8C /* EXPMatchers+beLessThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 0230190DDFC91DA732D8624EF3C54A9E /* EXPMatchers+beLessThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		46F312CBB94BAE62B58D3D7AE28E8DBD /* EXPMatchers+contain.m in Sources */ = {isa = PBXBuildFile; fileRef = A76D476E5FC248FFF04B019CFE53E21A /* EXPMatchers+contain.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		475BBFA6E99B39CB8429C0B71972E445 /* SpectaTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 7146A0979739F3A21FF50C0953C8D2A0 /* SpectaTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		486B65BB914388EA36C58304C6039F1F /* Analytics-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CBFEA0C6D4EBA470E98B90635BAB38B2 /* Analytics-dummy.m */; };
-		487899F028C39C1A518547A1AB2F625A /* EXPDoubleTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = F3165B876D08CD102EA891025959EB19 /* EXPDoubleTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		49496209C5711E0D5A4A51DCF8FB8DEC /* SEGGoogleAnalyticsIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = F7DE9BBD243370BF8EFFF25D7E85CD4C /* SEGGoogleAnalyticsIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		49EFE75BAF060A33327F3CE8C18436F2 /* EXPMatcherHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = E3554BD7A107F9879E5EB62B4F8C2A35 /* EXPMatcherHelpers.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		4A8FD952823FAC67C04EB7F52F6B3881 /* SPTSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5400AA6F166FE7EE163E4966C6466D21 /* SPTSpec.m */; };
-		4B0EA949E5076B09ED0B24C22053F953 /* SPTGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 203F34C34A866E23F7B4CF5C17CA8EA5 /* SPTGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		503BF36CDAFC3DE4E6862924EFF5DF1D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */; };
-		50479B6EF1A2C74265F5AB553CFC56F2 /* Specta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = EEA295B5F005DA5BE3281CE44E4D995D /* Specta-dummy.m */; };
-		539C2C0907CA46CC4DE78E19B1AFFA8E /* SEGBluetooth.h in Headers */ = {isa = PBXBuildFile; fileRef = 9317CA06C334C88F084CD88BF04618ED /* SEGBluetooth.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		562BE99A6F630E709218EB9B3CF36E90 /* EXPMatchers+haveCountOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 79C247F75A75B96048791BEBE10B0B03 /* EXPMatchers+haveCountOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		57FA908BAA9E8857F78965B0CF320A22 /* SPTTestSuite.m in Sources */ = {isa = PBXBuildFile; fileRef = 66266AC3D90E76C93DFDBE52120305BE /* SPTTestSuite.m */; };
-		5898D23317AA2AC18E0FD933409C5E9F /* SEGGoogleAnalyticsIntegrationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 99AF585D638505D532A2B91329682F8E /* SEGGoogleAnalyticsIntegrationFactory.m */; };
-		5DD6A636555E18CB2AEB2903355B1551 /* Segment-GoogleAnalytics-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D671DB178CE02AEA19CBF062C3596692 /* Segment-GoogleAnalytics-dummy.m */; };
-		5E8F33E777456DA63CA2D902508A9058 /* EXPMatchers+beTruthy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AF5B07DCDCBE1BC22042D777A38B464 /* EXPMatchers+beTruthy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		5F6D96E64F890BDC4A75B73C3D50A0DD /* EXPMatchers+beCloseTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 86F591E03C6A2C071821D67283CFF54D /* EXPMatchers+beCloseTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		605CADFBD63A01EDAA5A251B60B2C6AA /* SPTTestSuite.h in Headers */ = {isa = PBXBuildFile; fileRef = B658C2B4FB8A46E92A154CFF1291537A /* SPTTestSuite.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		60D3CCEB5B53542228790ABD8885AF42 /* NSValue+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = BDA0B809F5CE67054059064E81CBAF5F /* NSValue+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		63D0CD4F0FB5A6103E1DDB46E876CBB6 /* EXPMatchers+beKindOf.m in Sources */ = {isa = PBXBuildFile; fileRef = C90EFAB73AD4A25DD1A311ACFB030AE8 /* EXPMatchers+beKindOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		66081D3480D1FA028C4DE2344BF616D4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */; };
-		6656F35498E5573ED9F890D8B828B828 /* SPTCompiledExample.h in Headers */ = {isa = PBXBuildFile; fileRef = 67D33B9C02CA7DFBF73919E3CE31AD7A /* SPTCompiledExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		66ED669D42B1035789CE51D6A5C86EB0 /* SEGGroupPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 52C7898921A306F30450C3679C050D2A /* SEGGroupPayload.m */; };
-		68E10C74572004B18490C31A0757E3B2 /* SEGBluetooth.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C1CE6534A62FA634E7867F189D282C2 /* SEGBluetooth.m */; };
-		6924E116731D7079958063A3EE0781ED /* EXPMatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = 03F690173163BA691C98E1D242100544 /* EXPMatchers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		69363A59A4E2FF95D6A62AA88641A20A /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 279AA6492631DEFA8C439A9C088EEB8A /* XCTest.framework */; };
-		69EBB956302554EA37775F4D806BC4DD /* EXPMatchers+postNotification.m in Sources */ = {isa = PBXBuildFile; fileRef = 19BA3A4E9AB74D50BA74D05C5A3A497B /* EXPMatchers+postNotification.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		6A4E3ACA285A21392936C110E7EC91F0 /* EXPDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 195673BC1D4EBD3D604A447FFEF80200 /* EXPDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6CBB0742821FD4D346404011AE148582 /* SEGScreenPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 231B198CBFD8DDBEF36D16F274FC83AE /* SEGScreenPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6D37BEAA1FC469C3582CACB4E9766502 /* EXPMatchers+beSupersetOf.m in Sources */ = {isa = PBXBuildFile; fileRef = ED4F564CFDAA4CBE9BBFBECE5695AA05 /* EXPMatchers+beSupersetOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		6EB2498C2AFB1DF8555CB7C1EF89CA5C /* EXPMatchers+raiseWithReason.h in Headers */ = {isa = PBXBuildFile; fileRef = DE132C2A739AD46783858B794AD9EEEA /* EXPMatchers+raiseWithReason.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		6FF568E538D78F99F2EA1ED159B99766 /* Pods-Segment-GoogleAnalytics_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 666C57509FA1B9FD91574E36B4521896 /* Pods-Segment-GoogleAnalytics_Tests-dummy.m */; };
-		70545E4EA86C6E593A2A9F6731DA8F6D /* EXPMatchers+beTruthy.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B073B349D98A4F02811E8A0E77D58BC /* EXPMatchers+beTruthy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		70F1E51CF39B72EA90BB9F19C3056733 /* SPTExcludeGlobalBeforeAfterEach.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ECBFFA672D10773C52B801D99B88FBE /* SPTExcludeGlobalBeforeAfterEach.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7436C602BB1CA7C91560C28DE749357B /* EXPMatchers+beInTheRangeOf.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E4490F950B5EC6EAC20E6BD37E9C14E /* EXPMatchers+beInTheRangeOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		74707D5ABEC55B3084F52C40A4227B06 /* EXPMatchers+beNil.h in Headers */ = {isa = PBXBuildFile; fileRef = 4DC954F6F5AB56AE2D793E9ACA45624D /* EXPMatchers+beNil.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		76331E71086C8CD5118A69B046D8F0FB /* EXPMatchers+endWith.h in Headers */ = {isa = PBXBuildFile; fileRef = 8499D866C1900FB26A437C8FE263DB5E /* EXPMatchers+endWith.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		779CFE8771E1EF63F1313ABEBCECAA4A /* EXPFloatTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = 2743254252516E0A88873C5402573C5B /* EXPFloatTuple.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		7AC91F55DAAA2F0223A97BEFF8BCAF68 /* ExpectaSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A1C939D28292C3A5B4011F361790762 /* ExpectaSupport.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7F99F346CEC7597BC4AD63F1E966D594 /* SEGAnalyticsRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = CA511D8C5CCB276C4F4E948BD4A5939F /* SEGAnalyticsRequest.m */; };
-		7FEE0E8D094D7BCCAC7129473EE05ADC /* EXPMatchers+raise.m in Sources */ = {isa = PBXBuildFile; fileRef = 799B3B17E7D0BC474B86DA58267CBEE4 /* EXPMatchers+raise.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		8059E5674B08670B0A002D564FFABF44 /* EXPMatchers+equal.m in Sources */ = {isa = PBXBuildFile; fileRef = 277DE8AADE10662CAE402205802458BA /* EXPMatchers+equal.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		872948DAF79618AD725E0BF364E5DDD4 /* NSValue+Expecta.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F5D27B4777037698149BC2D9793405F /* NSValue+Expecta.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		8A87FB401B93066DD8C85AAB9CDBC11A /* SPTSharedExampleGroups.m in Sources */ = {isa = PBXBuildFile; fileRef = F2848ECE86915EED9032636E866D125F /* SPTSharedExampleGroups.m */; };
-		8B1B60B7C24DCFAC0081FE5432C10942 /* SEGSegmentIntegrationFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = A35484475812F6496D912E772717EE78 /* SEGSegmentIntegrationFactory.m */; };
-		8DF90D623F7F9015EEE9F1D7FEE7E053 /* EXPBlockDefinedMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 463DA29EAC33AE0F642267ADB9876178 /* EXPBlockDefinedMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8F674582EE71972EE60EFD96C1F173D5 /* EXPMatchers+beGreaterThan.h in Headers */ = {isa = PBXBuildFile; fileRef = C57F3C0E6485F86FF3B4BBF6323AA0F2 /* EXPMatchers+beGreaterThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8F8B382D1231AE6FCA478E3C79F036AD /* SEGAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 91A2E492978527A73B3C4C3DD6B91C97 /* SEGAnalytics.m */; };
-		9019F9233E2A8B04A82C1B8D0274F09F /* EXPMatchers+beSupersetOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 95513FEBF6B22034689515724F049996 /* EXPMatchers+beSupersetOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		901C95FA513F8BEC6992EE457A527DE1 /* SEGAnalyticsUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C65EAD9F4779A546336645EC8E51355 /* SEGAnalyticsUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		91716783ABA4BA9B79B0501A0CDB59D9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */; };
-		956FB3AB698AF3DA776A9F24AA79C229 /* NSObject+Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = EF3EB8C9DCBBEF065C7190483B798529 /* NSObject+Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		97E91EC237B8623D895DBF6092034AD7 /* EXPMatchers+beInTheRangeOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 0632D8C7A85E2AB40699726F5382E847 /* EXPMatchers+beInTheRangeOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		98A22457F5E28CAF0B7E113A6D4142A1 /* SEGAnalyticsRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 2837272F75DD845EF2A91B94FA9E38AA /* SEGAnalyticsRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9B546D0F895D9B5A8316B948CEE95C77 /* EXPMatchers+beKindOf.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A96A585C0DF065295FEE69BB53944E9 /* EXPMatchers+beKindOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9F4084E6D71859700239E620D3D1BA2D /* SpectaUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 568C2BF10FCA51F625ECC214C3A9D520 /* SpectaUtility.m */; };
-		A26F992E8831118311F3DB7CB830595A /* EXPMatchers+raiseWithReason.m in Sources */ = {isa = PBXBuildFile; fileRef = 80C8D930FC5B078021D346DAB2B72B81 /* EXPMatchers+raiseWithReason.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		A2A91F93C68DAE8C18FE53F6EA15D54D /* SEGReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 81B495005EBD1E18D49D930C9F0DE1A4 /* SEGReachability.m */; };
-		A65C491577A425AF82C53F4A40A0A24B /* EXPMatchers+beIdenticalTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A2F6E1360B9C61485920F5D5473A974 /* EXPMatchers+beIdenticalTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		A6854D311D55E2BBD8BFCE4E82DF3EA9 /* Expecta.h in Headers */ = {isa = PBXBuildFile; fileRef = 661A7213AFBB8E769759DBE86DCAE8EB /* Expecta.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A7141BC83638F4B38D4D312BAE3BDAC4 /* EXPMatchers+beginWith.m in Sources */ = {isa = PBXBuildFile; fileRef = C582A29AB08E63C474831C4D63A9B123 /* EXPMatchers+beginWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		A78EC25004EE56F06223E13322CB2FA6 /* SPTCompiledExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 20931BF25C1C314AD48793C2B3EFB1DD /* SPTCompiledExample.m */; };
-		A8490A46CB5206BCA5F90FCFBA2D731E /* EXPMatcherHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 305B6661988E84D5D0C3B158B277BEAC /* EXPMatcherHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AA7B402D31D86AE5E3DD083408311FF1 /* EXPMatchers+beCloseTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C84E03C3810D3CB1B6F36216A398A2E /* EXPMatchers+beCloseTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AAE75938ED3DD46BC00352B82D7CA890 /* EXPMatchers+raise.h in Headers */ = {isa = PBXBuildFile; fileRef = FE99B615AB863FEF83FD39F59E2A939D /* EXPMatchers+raise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AB1D6408D48F6ECF3FCE553BE73961F5 /* EXPMatchers+beIdenticalTo.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E91479DE86808F686A59942FC879D8E /* EXPMatchers+beIdenticalTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		AD6791D14732A3C17164F61CC72FFB0D /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 518A7131AD41523DC00501D702A1EF88 /* EXPMatchers+beGreaterThanOrEqualTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		B038AD02D30EC17B9D23EB9D1487382C /* SPTCallSite.m in Sources */ = {isa = PBXBuildFile; fileRef = 76948DA1B8E447BB5BAEBFBBF91D38EF /* SPTCallSite.m */; };
-		B09EF0FD07655A036EF25A09252EC9A9 /* SEGIdentifyPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 1701C01002B6CA774E41013BCDCF6F72 /* SEGIdentifyPayload.m */; };
-		B309BC0D714443A4A815F45FECB8AAB1 /* SEGLocation.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C9CEECF04FC9560D547C3380931D78B /* SEGLocation.m */; };
-		B33234F432A72D5E8B65694AE937B78F /* EXPMatchers+endWith.m in Sources */ = {isa = PBXBuildFile; fileRef = 61D10D4273167662735D83D780C56F89 /* EXPMatchers+endWith.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		B5F7A213B1C490590EFAB25DF6AFD48A /* SEGAnalyticsUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 11DDFBEEBD749A88975C8606A445C015 /* SEGAnalyticsUtils.m */; };
-		B7D89DBEEF4C2A2165C2A1E127947D9A /* XCTest+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 55345A779F22C7147507AC695CE3B85B /* XCTest+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B87904014217EC9142A60100E6D363E3 /* SEGPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D32FAD33571B227BE06BBB6E80444A8 /* SEGPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B9BD17A05F5CCA4B178E0E0DC065D6D5 /* SPTExample.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A3BD1002DD3D3877A0AD6DC83B9AFC7 /* SPTExample.m */; };
-		BC021CC978BE68B2BE0A690878FB54AF /* SEGIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E0733A0038EE5736FF18B5A63792DA6 /* SEGIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BD30B724A71CF5D6E93805B7615EC79C /* EXPMatchers+beSubclassOf.m in Sources */ = {isa = PBXBuildFile; fileRef = C86EDDCE44ACD911BBDB34FA398F8A83 /* EXPMatchers+beSubclassOf.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C186082DC500722CB26121EAB9F92126 /* SPTSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 41D48B8BD24D516FA56686BDD2A113C2 /* SPTSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C2BFF99EB859FD7056CF72C4850693D1 /* EXPMatchers+conformTo.m in Sources */ = {isa = PBXBuildFile; fileRef = A1FCE77270936EE316746356E3A413E1 /* EXPMatchers+conformTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C345B90819C4CE033B07926CFEEF9644 /* SEGGoogleAnalyticsIntegrationFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 51F974C6782C68F90D278FCEA769A59E /* SEGGoogleAnalyticsIntegrationFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		C6671739E8C5904113586F8BEBBC9780 /* EXPMatchers+beLessThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 2C9B4D847287245CC715A02DD0F307E1 /* EXPMatchers+beLessThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		C98F5401E5C1AB6512BE50C3B7CEA9BF /* EXPMatchers+match.h in Headers */ = {isa = PBXBuildFile; fileRef = 39E9492F7292B43EF5DE6007F51DA0EC /* EXPMatchers+match.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CB08C9C83ABDBE55762A423ED48491EF /* EXPMatchers+beGreaterThan.m in Sources */ = {isa = PBXBuildFile; fileRef = 17A3F1607267A4CD0D8B76C017299F78 /* EXPMatchers+beGreaterThan.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		CBC8E95BD4789904887E8E44506F2E19 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */; };
-		CCCD4FA4F4339DED24A487A9312D9526 /* SpectaDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 4511AE2A42381FF1A3B3C12144FC0C0E /* SpectaDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		CF95446EA555B49150EA7270096D78B2 /* EXPBlockDefinedMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = C1A93C3D14968665C68BD6069241F78C /* EXPBlockDefinedMatcher.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		D3C948582E14C4F4A6D87738C5EB0EC1 /* SpectaUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 7FD3BC43A6C31A97BF932D9F18311E76 /* SpectaUtility.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D42799488F38F2DB8A580730CEE13CE6 /* EXPMatchers+beInstanceOf.h in Headers */ = {isa = PBXBuildFile; fileRef = A9B2D68316EF35682E3B24DD33C44B66 /* EXPMatchers+beInstanceOf.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DA51317333A94F4A9B3B1FF0A1DF71EF /* SPTExample.h in Headers */ = {isa = PBXBuildFile; fileRef = D327A699D86B9304B2D3FEAB534333DC /* SPTExample.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DAC08D09C7E4411C8B01CD2FCFCD247B /* SEGReachability.h in Headers */ = {isa = PBXBuildFile; fileRef = 6BD6385C8632CDBB33C3F694D32D44AC /* SEGReachability.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DD7BED725086CF410512F736DE7AA95B /* SEGTrackPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AD7BB555A10EBB24F11166027FCCB24 /* SEGTrackPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DDA0131B5E07737BB02250EC8E73A2F6 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */; };
-		DFF580AE359407E841BA8D8DDCE6E299 /* EXPMatchers+beLessThan.h in Headers */ = {isa = PBXBuildFile; fileRef = 2494E91B1F913E639B70B22D66D6B52F /* EXPMatchers+beLessThan.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E06376455C1D5E45B97ACDC5438FC15B /* EXPMatchers+beNil.m in Sources */ = {isa = PBXBuildFile; fileRef = 4075E3A20D226B9478030380B33E3EEE /* EXPMatchers+beNil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		E2EBD18BA89D3FF648947DF31FA12D44 /* EXPMatchers+respondTo.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F7810CA7C3360CA27786A4189D1F13A /* EXPMatchers+respondTo.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		E617E37B8DE4B930EC91E78E7B804A9C /* SEGAliasPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 1638149FA560B7ED8704012F6E32B010 /* SEGAliasPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E867CBF850D20C314BF4BD790432455D /* EXPMatchers+respondTo.h in Headers */ = {isa = PBXBuildFile; fileRef = A5040B544FBFCCA344AF6F5D7ADDFADF /* EXPMatchers+respondTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E8D41CF69BC7D498C16F3887A021F4BA /* SpectaDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = C1C171166E9393E8C112CDC72CDEBF13 /* SpectaDSL.m */; };
-		EB27473B3153D1A32E331F8C3BC98E15 /* SEGPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = FCF10D4D8159FFF95CFCDB62577AA8E4 /* SEGPayload.m */; };
-		EE52A320EC3155B114104E06396D1B59 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */ = {isa = PBXBuildFile; fileRef = EC523F5B18127D76F5586636012C547F /* EXPMatchers+beLessThanOrEqualTo.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		EF305FCB32346C76431C1202E7AD467B /* SEGIdentifyPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 8857DA884D845E55149E2D0721FE2C41 /* SEGIdentifyPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F1F4E65611F5567A86AF797EAC3E225B /* EXPMatchers+beFalsy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4D12FAE56109712094DA78D38B05DA2C /* EXPMatchers+beFalsy.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		F280BEB32C116B6249D42E50A697B04B /* SEGSegmentIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 7ED4DAD1A4FB242A6CE917329C32BDCB /* SEGSegmentIntegration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F40B16934B552AC428855EC01D39473C /* SPTCallSite.h in Headers */ = {isa = PBXBuildFile; fileRef = 789F69996FFDE3AECA5AF9C317B256B6 /* SPTCallSite.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F4CA468B5A9F8FF2A4DB8B236A8E71BF /* EXPMatchers+beFalsy.h in Headers */ = {isa = PBXBuildFile; fileRef = C4E98ABEAC39F16F3D1D5D53F15A2F9F /* EXPMatchers+beFalsy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F6A5E9881D67168D9B9BFA5FCD834596 /* SEGGroupPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = 97F182F971933BFEF29A646F7D22423E /* SEGGroupPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F9F824608D10EAF566AE7C2C9AD73CC5 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 279AA6492631DEFA8C439A9C088EEB8A /* XCTest.framework */; };
-		FBBEEFC1F77A002E76A2E9CBC801BABF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */; };
-		FDF72740DBC37AFACFED73ED42282383 /* Expecta-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 22F3505207F93C01E28757C157D01EEB /* Expecta-dummy.m */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		0082E7EAE614FC3473892AEBEDFFBB1B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 9A7702F7DB899DC0B318CF2119620155;
-			remoteInfo = Specta;
-		};
-		2CDEF66D198FA82D47E8C5065823C834 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E703EF8141AB3D56D46182B4EA5FB571;
-			remoteInfo = Analytics;
-		};
-		30F56C861EE89640CE6C9F59CA056520 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 859E063BB03DDB2C5D9A99DB427478EA;
-			remoteInfo = "Segment-GoogleAnalytics";
-		};
-		548C4C3F0491EA8ADB64767E149A8DF5 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E703EF8141AB3D56D46182B4EA5FB571;
-			remoteInfo = Analytics;
-		};
-		A4644EDA4C4D6F333FB54B441CB67E93 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 2F501FE84845EAD97B9087DAFCBBEE0E;
-			remoteInfo = Expecta;
-		};
-		BCF9B107370736590CF156865DDE2E24 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 859E063BB03DDB2C5D9A99DB427478EA;
-			remoteInfo = "Segment-GoogleAnalytics";
-		};
-		F9015232CB5F2A63DB560C88DCF86512 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = E703EF8141AB3D56D46182B4EA5FB571;
-			remoteInfo = Analytics;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXFileReference section */
-		003E1FF25B624503C0B7DE8E09FFCD2E /* Specta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Specta.xcconfig; sourceTree = "<group>"; };
-		00AA78757DDCD095BADCC948F96D9918 /* Pods-Segment-GoogleAnalytics_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Segment-GoogleAnalytics_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		0230190DDFC91DA732D8624EF3C54A9E /* EXPMatchers+beLessThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.m"; sourceTree = "<group>"; };
-		03F690173163BA691C98E1D242100544 /* EXPMatchers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatchers.h; path = Expecta/Matchers/EXPMatchers.h; sourceTree = "<group>"; };
-		04CCA4E932E4555FE104E08F5A1F899A /* Segment-GoogleAnalytics-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Segment-GoogleAnalytics-prefix.pch"; sourceTree = "<group>"; };
-		0632D8C7A85E2AB40699726F5382E847 /* EXPMatchers+beInTheRangeOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInTheRangeOf.h"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.h"; sourceTree = "<group>"; };
-		067AB382C6EAF94F9525C2D3E798EA89 /* Pods-Segment-GoogleAnalytics_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Segment-GoogleAnalytics_Tests-frameworks.sh"; sourceTree = "<group>"; };
-		0B89D65F93B8B964E748359C59731131 /* Expecta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Expecta-prefix.pch"; sourceTree = "<group>"; };
-		0D32FAD33571B227BE06BBB6E80444A8 /* SEGPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGPayload.h; path = Pod/Classes/Integrations/SEGPayload.h; sourceTree = "<group>"; };
-		0D61BFA15E780468CFF692FA8FFE5AFE /* EXPExpect.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPExpect.m; path = Expecta/EXPExpect.m; sourceTree = "<group>"; };
-		0D99CDFBEB811EE97A2EE7BD42C8C872 /* GAIDictionaryBuilder.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIDictionaryBuilder.h; path = Headers/Public/GAIDictionaryBuilder.h; sourceTree = "<group>"; };
-		1090ADEE4E406645BC0603EF794F19AE /* SEGGoogleAnalyticsIntegration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SEGGoogleAnalyticsIntegration.m; sourceTree = "<group>"; };
-		11DDFBEEBD749A88975C8606A445C015 /* SEGAnalyticsUtils.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalyticsUtils.m; path = Pod/Classes/Internal/SEGAnalyticsUtils.m; sourceTree = "<group>"; };
-		147BB6B93BF01AB27D7C213F8FFC0F0A /* GAITrackedViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAITrackedViewController.h; path = Headers/Public/GAITrackedViewController.h; sourceTree = "<group>"; };
-		1638149FA560B7ED8704012F6E32B010 /* SEGAliasPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAliasPayload.h; path = Pod/Classes/Integrations/SEGAliasPayload.h; sourceTree = "<group>"; };
-		1701C01002B6CA774E41013BCDCF6F72 /* SEGIdentifyPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGIdentifyPayload.m; path = Pod/Classes/Integrations/SEGIdentifyPayload.m; sourceTree = "<group>"; };
-		17A3F1607267A4CD0D8B76C017299F78 /* EXPMatchers+beGreaterThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThan.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.m"; sourceTree = "<group>"; };
-		195673BC1D4EBD3D604A447FFEF80200 /* EXPDefines.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDefines.h; path = Expecta/EXPDefines.h; sourceTree = "<group>"; };
-		19BA3A4E9AB74D50BA74D05C5A3A497B /* EXPMatchers+postNotification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+postNotification.m"; path = "Expecta/Matchers/EXPMatchers+postNotification.m"; sourceTree = "<group>"; };
-		1BB5FCB799A3E132B5FAA78FAF5AD39C /* libExpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libExpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		1DB0E1341AF1923C7D66E6695062860B /* Expecta.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Expecta.xcconfig; sourceTree = "<group>"; };
-		1ECBFFA672D10773C52B801D99B88FBE /* SPTExcludeGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExcludeGlobalBeforeAfterEach.h; path = Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
-		203F34C34A866E23F7B4CF5C17CA8EA5 /* SPTGlobalBeforeAfterEach.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTGlobalBeforeAfterEach.h; path = Specta/Specta/SPTGlobalBeforeAfterEach.h; sourceTree = "<group>"; };
-		20931BF25C1C314AD48793C2B3EFB1DD /* SPTCompiledExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCompiledExample.m; path = Specta/Specta/SPTCompiledExample.m; sourceTree = "<group>"; };
-		22F3505207F93C01E28757C157D01EEB /* Expecta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Expecta-dummy.m"; sourceTree = "<group>"; };
-		22FAD7D819C780BD3941E8361C9DE50E /* EXPMatchers+beginWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beginWith.h"; path = "Expecta/Matchers/EXPMatchers+beginWith.h"; sourceTree = "<group>"; };
-		231B198CBFD8DDBEF36D16F274FC83AE /* SEGScreenPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGScreenPayload.h; path = Pod/Classes/Integrations/SEGScreenPayload.h; sourceTree = "<group>"; };
-		2494E91B1F913E639B70B22D66D6B52F /* EXPMatchers+beLessThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThan.h"; path = "Expecta/Matchers/EXPMatchers+beLessThan.h"; sourceTree = "<group>"; };
-		2743254252516E0A88873C5402573C5B /* EXPFloatTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPFloatTuple.m; path = Expecta/EXPFloatTuple.m; sourceTree = "<group>"; };
-		277DE8AADE10662CAE402205802458BA /* EXPMatchers+equal.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+equal.m"; path = "Expecta/Matchers/EXPMatchers+equal.m"; sourceTree = "<group>"; };
-		279AA6492631DEFA8C439A9C088EEB8A /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
-		27B1B54BB2BA7B78455DCEB2FEF70BC6 /* XCTestCase+Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTestCase+Specta.h"; path = "Specta/Specta/XCTestCase+Specta.h"; sourceTree = "<group>"; };
-		2837272F75DD845EF2A91B94FA9E38AA /* SEGAnalyticsRequest.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalyticsRequest.h; path = Pod/Classes/Internal/SEGAnalyticsRequest.h; sourceTree = "<group>"; };
-		2C9B4D847287245CC715A02DD0F307E1 /* EXPMatchers+beLessThan.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beLessThan.m"; path = "Expecta/Matchers/EXPMatchers+beLessThan.m"; sourceTree = "<group>"; };
-		2C9CEECF04FC9560D547C3380931D78B /* SEGLocation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGLocation.m; path = Pod/Classes/Internal/SEGLocation.m; sourceTree = "<group>"; };
-		2D88ACEFC22E13FCF6F27A591CCC1D53 /* EXPMatchers+conformTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+conformTo.h"; path = "Expecta/Matchers/EXPMatchers+conformTo.h"; sourceTree = "<group>"; };
-		2E0733A0038EE5736FF18B5A63792DA6 /* SEGIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegrationFactory.h; path = Pod/Classes/Integrations/SEGIntegrationFactory.h; sourceTree = "<group>"; };
-		2E91479DE86808F686A59942FC879D8E /* EXPMatchers+beIdenticalTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beIdenticalTo.h"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.h"; sourceTree = "<group>"; };
-		2FC2FBF5CAFA206F9C92EC6A22AC0B84 /* Analytics-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Analytics-prefix.pch"; sourceTree = "<group>"; };
-		305B6661988E84D5D0C3B158B277BEAC /* EXPMatcherHelpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcherHelpers.h; path = Expecta/Matchers/EXPMatcherHelpers.h; sourceTree = "<group>"; };
-		3756FB16CD0261AA42611CD5D01B88C7 /* SPTSharedExampleGroups.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSharedExampleGroups.h; path = Specta/Specta/SPTSharedExampleGroups.h; sourceTree = "<group>"; };
-		39E9492F7292B43EF5DE6007F51DA0EC /* EXPMatchers+match.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+match.h"; path = "Expecta/Matchers/EXPMatchers+match.h"; sourceTree = "<group>"; };
-		3ABC5E4B4982D08ED7380A4C08E3418C /* SEGSegmentIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSegmentIntegrationFactory.h; path = Pod/Classes/Internal/SEGSegmentIntegrationFactory.h; sourceTree = "<group>"; };
-		3AD7BB555A10EBB24F11166027FCCB24 /* SEGTrackPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGTrackPayload.h; path = Pod/Classes/Integrations/SEGTrackPayload.h; sourceTree = "<group>"; };
-		3E4490F950B5EC6EAC20E6BD37E9C14E /* EXPMatchers+beInTheRangeOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInTheRangeOf.m"; path = "Expecta/Matchers/EXPMatchers+beInTheRangeOf.m"; sourceTree = "<group>"; };
-		4075E3A20D226B9478030380B33E3EEE /* EXPMatchers+beNil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beNil.m"; path = "Expecta/Matchers/EXPMatchers+beNil.m"; sourceTree = "<group>"; };
-		41D48B8BD24D516FA56686BDD2A113C2 /* SPTSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTSpec.h; path = Specta/Specta/SPTSpec.h; sourceTree = "<group>"; };
-		41DDF8C028B6E5026AD5CC5BAD2AAA3B /* libSegment-GoogleAnalytics.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libSegment-GoogleAnalytics.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		4511AE2A42381FF1A3B3C12144FC0C0E /* SpectaDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaDSL.h; path = Specta/Specta/SpectaDSL.h; sourceTree = "<group>"; };
-		463DA29EAC33AE0F642267ADB9876178 /* EXPBlockDefinedMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPBlockDefinedMatcher.h; path = Expecta/EXPBlockDefinedMatcher.h; sourceTree = "<group>"; };
-		4A023A20387157632011915438018BA0 /* GAIEcommerceProductAction.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIEcommerceProductAction.h; path = Headers/Public/GAIEcommerceProductAction.h; sourceTree = "<group>"; };
-		4C1CE6534A62FA634E7867F189D282C2 /* SEGBluetooth.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGBluetooth.m; path = Pod/Classes/Internal/SEGBluetooth.m; sourceTree = "<group>"; };
-		4C84E03C3810D3CB1B6F36216A398A2E /* EXPMatchers+beCloseTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beCloseTo.h"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.h"; sourceTree = "<group>"; };
-		4D12FAE56109712094DA78D38B05DA2C /* EXPMatchers+beFalsy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beFalsy.m"; path = "Expecta/Matchers/EXPMatchers+beFalsy.m"; sourceTree = "<group>"; };
-		4DC954F6F5AB56AE2D793E9ACA45624D /* EXPMatchers+beNil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beNil.h"; path = "Expecta/Matchers/EXPMatchers+beNil.h"; sourceTree = "<group>"; };
-		4F399E73BB1F0DA1C2966C111EA9C7EE /* Pods-Segment-GoogleAnalytics_Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Segment-GoogleAnalytics_Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		4F7810CA7C3360CA27786A4189D1F13A /* EXPMatchers+respondTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+respondTo.m"; path = "Expecta/Matchers/EXPMatchers+respondTo.m"; sourceTree = "<group>"; };
-		518A7131AD41523DC00501D702A1EF88 /* EXPMatchers+beGreaterThanOrEqualTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beGreaterThanOrEqualTo.m"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.m"; sourceTree = "<group>"; };
-		51F974C6782C68F90D278FCEA769A59E /* SEGGoogleAnalyticsIntegrationFactory.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SEGGoogleAnalyticsIntegrationFactory.h; sourceTree = "<group>"; };
-		52C7898921A306F30450C3679C050D2A /* SEGGroupPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGGroupPayload.m; path = Pod/Classes/Integrations/SEGGroupPayload.m; sourceTree = "<group>"; };
-		5400AA6F166FE7EE163E4966C6466D21 /* SPTSpec.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSpec.m; path = Specta/Specta/SPTSpec.m; sourceTree = "<group>"; };
-		55345A779F22C7147507AC695CE3B85B /* XCTest+Private.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "XCTest+Private.h"; path = "Specta/Specta/XCTest+Private.h"; sourceTree = "<group>"; };
-		558A49FF40959AE7147F14C765269D33 /* Analytics.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Analytics.xcconfig; sourceTree = "<group>"; };
-		568C2BF10FCA51F625ECC214C3A9D520 /* SpectaUtility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaUtility.m; path = Specta/Specta/SpectaUtility.m; sourceTree = "<group>"; };
-		56BBCF71F950D6191CD6B1B91A85FA82 /* EXPFloatTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPFloatTuple.h; path = Expecta/EXPFloatTuple.h; sourceTree = "<group>"; };
-		56F3B4B2BD22271258A1CB037C17CF99 /* SPTExampleGroup.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExampleGroup.h; path = Specta/Specta/SPTExampleGroup.h; sourceTree = "<group>"; };
-		578995B5D7A1B89485396FD3F985F3C1 /* Specta-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Specta-prefix.pch"; sourceTree = "<group>"; };
-		5A2F6E1360B9C61485920F5D5473A974 /* EXPMatchers+beIdenticalTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beIdenticalTo.m"; path = "Expecta/Matchers/EXPMatchers+beIdenticalTo.m"; sourceTree = "<group>"; };
-		5A5D0FD313A4B5E5A78C8A34A9B71607 /* SEGScreenPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGScreenPayload.m; path = Pod/Classes/Integrations/SEGScreenPayload.m; sourceTree = "<group>"; };
-		5F5D27B4777037698149BC2D9793405F /* NSValue+Expecta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSValue+Expecta.m"; path = "Expecta/NSValue+Expecta.m"; sourceTree = "<group>"; };
-		61D10D4273167662735D83D780C56F89 /* EXPMatchers+endWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+endWith.m"; path = "Expecta/Matchers/EXPMatchers+endWith.m"; sourceTree = "<group>"; };
-		661A7213AFBB8E769759DBE86DCAE8EB /* Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Expecta.h; path = Expecta/Expecta.h; sourceTree = "<group>"; };
-		66266AC3D90E76C93DFDBE52120305BE /* SPTTestSuite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTTestSuite.m; path = Specta/Specta/SPTTestSuite.m; sourceTree = "<group>"; };
-		666C57509FA1B9FD91574E36B4521896 /* Pods-Segment-GoogleAnalytics_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Segment-GoogleAnalytics_Tests-dummy.m"; sourceTree = "<group>"; };
-		66A04F37AA8446E5F76E605B220607FA /* EXPUnsupportedObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPUnsupportedObject.m; path = Expecta/EXPUnsupportedObject.m; sourceTree = "<group>"; };
-		67D33B9C02CA7DFBF73919E3CE31AD7A /* SPTCompiledExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCompiledExample.h; path = Specta/Specta/SPTCompiledExample.h; sourceTree = "<group>"; };
-		6807539CEC31F5EB61DC3B93ADD174C7 /* SPTExampleGroup.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExampleGroup.m; path = Specta/Specta/SPTExampleGroup.m; sourceTree = "<group>"; };
-		6A1C939D28292C3A5B4011F361790762 /* ExpectaSupport.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaSupport.h; path = Expecta/ExpectaSupport.h; sourceTree = "<group>"; };
-		6A2147C8C8E0A818D9BC42DC2F23709B /* EXPMatchers+beSubclassOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSubclassOf.h"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.h"; sourceTree = "<group>"; };
-		6BD6385C8632CDBB33C3F694D32D44AC /* SEGReachability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGReachability.h; path = Pod/Classes/Internal/SEGReachability.h; sourceTree = "<group>"; };
-		7146A0979739F3A21FF50C0953C8D2A0 /* SpectaTypes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaTypes.h; path = Specta/Specta/SpectaTypes.h; sourceTree = "<group>"; };
-		74D3ACC6B6BEF1EDD07AE51CA1B7E60D /* libGoogleAnalytics.a */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = archive.ar; name = libGoogleAnalytics.a; path = Libraries/libGoogleAnalytics.a; sourceTree = "<group>"; };
-		7669417A2998C97CD154ABD987C5334E /* SEGSegmentIntegration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGSegmentIntegration.m; path = Pod/Classes/Internal/SEGSegmentIntegration.m; sourceTree = "<group>"; };
-		76948DA1B8E447BB5BAEBFBBF91D38EF /* SPTCallSite.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTCallSite.m; path = Specta/Specta/SPTCallSite.m; sourceTree = "<group>"; };
-		76FDA2EF06A82D029BE55F779402A351 /* EXPMatchers+contain.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+contain.h"; path = "Expecta/Matchers/EXPMatchers+contain.h"; sourceTree = "<group>"; };
-		789F69996FFDE3AECA5AF9C317B256B6 /* SPTCallSite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTCallSite.h; path = Specta/Specta/SPTCallSite.h; sourceTree = "<group>"; };
-		799B3B17E7D0BC474B86DA58267CBEE4 /* EXPMatchers+raise.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raise.m"; path = "Expecta/Matchers/EXPMatchers+raise.m"; sourceTree = "<group>"; };
-		79C247F75A75B96048791BEBE10B0B03 /* EXPMatchers+haveCountOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+haveCountOf.m"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.m"; sourceTree = "<group>"; };
-		7C1E9D81E228F9B07251DEEB275F4744 /* Specta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Specta.h; path = Specta/Specta/Specta.h; sourceTree = "<group>"; };
-		7ED4DAD1A4FB242A6CE917329C32BDCB /* SEGSegmentIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGSegmentIntegration.h; path = Pod/Classes/Internal/SEGSegmentIntegration.h; sourceTree = "<group>"; };
-		7FD3BC43A6C31A97BF932D9F18311E76 /* SpectaUtility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SpectaUtility.h; path = Specta/Specta/SpectaUtility.h; sourceTree = "<group>"; };
-		803929AB0EC5B999F71365235E2FC569 /* GAITracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAITracker.h; path = Headers/Public/GAITracker.h; sourceTree = "<group>"; };
-		80C8D930FC5B078021D346DAB2B72B81 /* EXPMatchers+raiseWithReason.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+raiseWithReason.m"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.m"; sourceTree = "<group>"; };
-		81B495005EBD1E18D49D930C9F0DE1A4 /* SEGReachability.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGReachability.m; path = Pod/Classes/Internal/SEGReachability.m; sourceTree = "<group>"; };
-		8499D866C1900FB26A437C8FE263DB5E /* EXPMatchers+endWith.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+endWith.h"; path = "Expecta/Matchers/EXPMatchers+endWith.h"; sourceTree = "<group>"; };
-		855FF2069FE35409211B068CF74D1BC9 /* Pods-Segment-GoogleAnalytics_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-Segment-GoogleAnalytics_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		869F6CDA9DFD53454C106CBA668F580E /* EXPUnsupportedObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPUnsupportedObject.h; path = Expecta/EXPUnsupportedObject.h; sourceTree = "<group>"; };
-		86F591E03C6A2C071821D67283CFF54D /* EXPMatchers+beCloseTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beCloseTo.m"; path = "Expecta/Matchers/EXPMatchers+beCloseTo.m"; sourceTree = "<group>"; };
-		8811C2CFB32EDC145242E31D1D6000C3 /* libSpecta.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSpecta.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8857DA884D845E55149E2D0721FE2C41 /* SEGIdentifyPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIdentifyPayload.h; path = Pod/Classes/Integrations/SEGIdentifyPayload.h; sourceTree = "<group>"; };
-		8A96A585C0DF065295FEE69BB53944E9 /* EXPMatchers+beKindOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beKindOf.h"; path = "Expecta/Matchers/EXPMatchers+beKindOf.h"; sourceTree = "<group>"; };
-		8AF5B07DCDCBE1BC22042D777A38B464 /* EXPMatchers+beTruthy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beTruthy.m"; path = "Expecta/Matchers/EXPMatchers+beTruthy.m"; sourceTree = "<group>"; };
-		8B073B349D98A4F02811E8A0E77D58BC /* EXPMatchers+beTruthy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beTruthy.h"; path = "Expecta/Matchers/EXPMatchers+beTruthy.h"; sourceTree = "<group>"; };
-		8C65EAD9F4779A546336645EC8E51355 /* SEGAnalyticsUtils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalyticsUtils.h; path = Pod/Classes/Internal/SEGAnalyticsUtils.h; sourceTree = "<group>"; };
-		8DC6005FC38AC1939F82F6C1FB9A2E36 /* EXPMatchers+postNotification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+postNotification.h"; path = "Expecta/Matchers/EXPMatchers+postNotification.h"; sourceTree = "<group>"; };
-		8DDB38718F95D76871BD12B66C61FB29 /* GAIEcommerceProduct.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIEcommerceProduct.h; path = Headers/Public/GAIEcommerceProduct.h; sourceTree = "<group>"; };
-		90552A900C20BA732E285A6C8CDB4660 /* EXPMatchers+beInstanceOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beInstanceOf.m"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.m"; sourceTree = "<group>"; };
-		90652227DA6C2B4C6C8E843F2F8BAC21 /* ExpectaObject.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaObject.m; path = Expecta/ExpectaObject.m; sourceTree = "<group>"; };
-		90A6E1569ECE25A96D932D7CB0456A00 /* EXPMatchers+equal.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+equal.h"; path = "Expecta/Matchers/EXPMatchers+equal.h"; sourceTree = "<group>"; };
-		91A2E492978527A73B3C4C3DD6B91C97 /* SEGAnalytics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalytics.m; path = Pod/Classes/SEGAnalytics.m; sourceTree = "<group>"; };
-		9317CA06C334C88F084CD88BF04618ED /* SEGBluetooth.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGBluetooth.h; path = Pod/Classes/Internal/SEGBluetooth.h; sourceTree = "<group>"; };
-		95513FEBF6B22034689515724F049996 /* EXPMatchers+beSupersetOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beSupersetOf.h"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.h"; sourceTree = "<group>"; };
-		97F182F971933BFEF29A646F7D22423E /* SEGGroupPayload.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGGroupPayload.h; path = Pod/Classes/Integrations/SEGGroupPayload.h; sourceTree = "<group>"; };
-		986E88CA93CED9C4B4963349457B2AA8 /* libPods-Segment-GoogleAnalytics_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Segment-GoogleAnalytics_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		98AF2EF29263F6E5F2917A01134D91A1 /* Pods-Segment-GoogleAnalytics_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Segment-GoogleAnalytics_Example-dummy.m"; sourceTree = "<group>"; };
-		9936109944D13524536A31583D20FC5C /* Pods-Segment-GoogleAnalytics_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Segment-GoogleAnalytics_Example-acknowledgements.plist"; sourceTree = "<group>"; };
-		99AF585D638505D532A2B91329682F8E /* SEGGoogleAnalyticsIntegrationFactory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = SEGGoogleAnalyticsIntegrationFactory.m; sourceTree = "<group>"; };
-		9A3BD1002DD3D3877A0AD6DC83B9AFC7 /* SPTExample.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTExample.m; path = Specta/Specta/SPTExample.m; sourceTree = "<group>"; };
-		9E7AED6529044F5A3F1798885FA0EB66 /* Segment-GoogleAnalytics.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Segment-GoogleAnalytics.xcconfig"; sourceTree = "<group>"; };
-		9F56505149E55909F48A9E238EC226EC /* GAIEcommercePromotion.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIEcommercePromotion.h; path = Headers/Public/GAIEcommercePromotion.h; sourceTree = "<group>"; };
-		A1FCE77270936EE316746356E3A413E1 /* EXPMatchers+conformTo.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+conformTo.m"; path = "Expecta/Matchers/EXPMatchers+conformTo.m"; sourceTree = "<group>"; };
-		A35484475812F6496D912E772717EE78 /* SEGSegmentIntegrationFactory.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGSegmentIntegrationFactory.m; path = Pod/Classes/Internal/SEGSegmentIntegrationFactory.m; sourceTree = "<group>"; };
-		A5040B544FBFCCA344AF6F5D7ADDFADF /* EXPMatchers+respondTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+respondTo.h"; path = "Expecta/Matchers/EXPMatchers+respondTo.h"; sourceTree = "<group>"; };
-		A76D476E5FC248FFF04B019CFE53E21A /* EXPMatchers+contain.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+contain.m"; path = "Expecta/Matchers/EXPMatchers+contain.m"; sourceTree = "<group>"; };
-		A8ABFA4EFC8E5E19332345AE253640A0 /* libAdIdAccessLibrary.a */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = archive.ar; name = libAdIdAccessLibrary.a; path = Libraries/libAdIdAccessLibrary.a; sourceTree = "<group>"; };
-		A8BCFD4057C083FF8B2B91CAA2A517AD /* Pods-Segment-GoogleAnalytics_Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Segment-GoogleAnalytics_Example-frameworks.sh"; sourceTree = "<group>"; };
-		A9B2D68316EF35682E3B24DD33C44B66 /* EXPMatchers+beInstanceOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beInstanceOf.h"; path = "Expecta/Matchers/EXPMatchers+beInstanceOf.h"; sourceTree = "<group>"; };
-		AA87D29C4C4D9CB70A5BB9010C93E406 /* SEGAliasPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAliasPayload.m; path = Pod/Classes/Integrations/SEGAliasPayload.m; sourceTree = "<group>"; };
-		AAAFAFFB150A80628C686DDD8D642B9D /* XCTestCase+Specta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestCase+Specta.m"; path = "Specta/Specta/XCTestCase+Specta.m"; sourceTree = "<group>"; };
-		B4B89A8180E266D6FD109356EBE762DA /* EXPDoubleTuple.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPDoubleTuple.h; path = Expecta/EXPDoubleTuple.h; sourceTree = "<group>"; };
-		B658C2B4FB8A46E92A154CFF1291537A /* SPTTestSuite.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTTestSuite.h; path = Specta/Specta/SPTTestSuite.h; sourceTree = "<group>"; };
-		B9ADDA29B749820D119249DA1929589E /* Pods-Segment-GoogleAnalytics_Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Segment-GoogleAnalytics_Example-resources.sh"; sourceTree = "<group>"; };
-		BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		BDA0B809F5CE67054059064E81CBAF5F /* NSValue+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSValue+Expecta.h"; path = "Expecta/NSValue+Expecta.h"; sourceTree = "<group>"; };
-		C0243D80A39E6D84988415B3206EBCF0 /* libAnalytics.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAnalytics.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		C1A93C3D14968665C68BD6069241F78C /* EXPBlockDefinedMatcher.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPBlockDefinedMatcher.m; path = Expecta/EXPBlockDefinedMatcher.m; sourceTree = "<group>"; };
-		C1C171166E9393E8C112CDC72CDEBF13 /* SpectaDSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SpectaDSL.m; path = Specta/Specta/SpectaDSL.m; sourceTree = "<group>"; };
-		C258607F1A902F6E3358877275B1C45D /* ExpectaSupport.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = ExpectaSupport.m; path = Expecta/ExpectaSupport.m; sourceTree = "<group>"; };
-		C4E98ABEAC39F16F3D1D5D53F15A2F9F /* EXPMatchers+beFalsy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beFalsy.h"; path = "Expecta/Matchers/EXPMatchers+beFalsy.h"; sourceTree = "<group>"; };
-		C57F3C0E6485F86FF3B4BBF6323AA0F2 /* EXPMatchers+beGreaterThan.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThan.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThan.h"; sourceTree = "<group>"; };
-		C582A29AB08E63C474831C4D63A9B123 /* EXPMatchers+beginWith.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beginWith.m"; path = "Expecta/Matchers/EXPMatchers+beginWith.m"; sourceTree = "<group>"; };
-		C6ABA54126ECDD4523DA27371E0E9474 /* Pods-Segment-GoogleAnalytics_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Segment-GoogleAnalytics_Example.debug.xcconfig"; sourceTree = "<group>"; };
-		C6B2685864B008D5854B7554B05FE815 /* SEGIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGIntegration.h; path = Pod/Classes/Integrations/SEGIntegration.h; sourceTree = "<group>"; };
-		C86EDDCE44ACD911BBDB34FA398F8A83 /* EXPMatchers+beSubclassOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSubclassOf.m"; path = "Expecta/Matchers/EXPMatchers+beSubclassOf.m"; sourceTree = "<group>"; };
-		C90EFAB73AD4A25DD1A311ACFB030AE8 /* EXPMatchers+beKindOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beKindOf.m"; path = "Expecta/Matchers/EXPMatchers+beKindOf.m"; sourceTree = "<group>"; };
-		C9E85A65EFBEA8CB9F441C68B3E492C1 /* EXPMatchers+beGreaterThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beGreaterThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.h"; sourceTree = "<group>"; };
-		CA511D8C5CCB276C4F4E948BD4A5939F /* SEGAnalyticsRequest.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGAnalyticsRequest.m; path = Pod/Classes/Internal/SEGAnalyticsRequest.m; sourceTree = "<group>"; };
-		CAAE62E8DB86653476BDEDF0B6664DBD /* Pods-Segment-GoogleAnalytics_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Segment-GoogleAnalytics_Tests.release.xcconfig"; sourceTree = "<group>"; };
-		CBFEA0C6D4EBA470E98B90635BAB38B2 /* Analytics-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Analytics-dummy.m"; sourceTree = "<group>"; };
-		CCDE6708F49E9734E245E14F26FEC611 /* GAI.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAI.h; path = Headers/Public/GAI.h; sourceTree = "<group>"; };
-		CF6E7D5EB1BE0988C685F173F5871BC8 /* GAILogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAILogger.h; path = Headers/Public/GAILogger.h; sourceTree = "<group>"; };
-		CFAE41FD7F6F5C7D8E508C03208FFF59 /* SEGAnalytics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGAnalytics.h; path = Pod/Classes/SEGAnalytics.h; sourceTree = "<group>"; };
-		D0B9C9663686AD4EC06FA9062E80A8F0 /* Pods-Segment-GoogleAnalytics_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Segment-GoogleAnalytics_Example.release.xcconfig"; sourceTree = "<group>"; };
-		D1CB69C27633FCC3576F1778EFC09B7D /* SEGLocation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SEGLocation.h; path = Pod/Classes/Internal/SEGLocation.h; sourceTree = "<group>"; };
-		D327A699D86B9304B2D3FEAB534333DC /* SPTExample.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = SPTExample.h; path = Specta/Specta/SPTExample.h; sourceTree = "<group>"; };
-		D58B97E6820E236C055063572F1E32A2 /* libPods-Segment-GoogleAnalytics_Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Segment-GoogleAnalytics_Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D671DB178CE02AEA19CBF062C3596692 /* Segment-GoogleAnalytics-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Segment-GoogleAnalytics-dummy.m"; sourceTree = "<group>"; };
-		D99400BFB9A624D8E051FED7A1BDF315 /* SEGTrackPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGTrackPayload.m; path = Pod/Classes/Integrations/SEGTrackPayload.m; sourceTree = "<group>"; };
-		DE132C2A739AD46783858B794AD9EEEA /* EXPMatchers+raiseWithReason.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raiseWithReason.h"; path = "Expecta/Matchers/EXPMatchers+raiseWithReason.h"; sourceTree = "<group>"; };
-		DE73CB6561F92F5CB79F28F7A4303749 /* EXPMatcher.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPMatcher.h; path = Expecta/EXPMatcher.h; sourceTree = "<group>"; };
-		E128AD4B837926B3A5A036D8E8DFECAD /* ExpectaObject.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = ExpectaObject.h; path = Expecta/ExpectaObject.h; sourceTree = "<group>"; };
-		E200A1F712D8C70CEE0ABE0ACDE4D904 /* Pods-Segment-GoogleAnalytics_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Segment-GoogleAnalytics_Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		E3554BD7A107F9879E5EB62B4F8C2A35 /* EXPMatcherHelpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPMatcherHelpers.m; path = Expecta/Matchers/EXPMatcherHelpers.m; sourceTree = "<group>"; };
-		E9E5EFF4A45283579A977D61C2FEE50C /* GAIEcommerceFields.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIEcommerceFields.h; path = Headers/Public/GAIEcommerceFields.h; sourceTree = "<group>"; };
-		EC523F5B18127D76F5586636012C547F /* EXPMatchers+beLessThanOrEqualTo.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+beLessThanOrEqualTo.h"; path = "Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.h"; sourceTree = "<group>"; };
-		ED4F564CFDAA4CBE9BBFBECE5695AA05 /* EXPMatchers+beSupersetOf.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+beSupersetOf.m"; path = "Expecta/Matchers/EXPMatchers+beSupersetOf.m"; sourceTree = "<group>"; };
-		EDB92F0DECBE15130358426D5213D6C8 /* EXPExpect.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = EXPExpect.h; path = Expecta/EXPExpect.h; sourceTree = "<group>"; };
-		EEA295B5F005DA5BE3281CE44E4D995D /* Specta-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Specta-dummy.m"; sourceTree = "<group>"; };
-		EF3EB8C9DCBBEF065C7190483B798529 /* NSObject+Expecta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSObject+Expecta.h"; path = "Expecta/NSObject+Expecta.h"; sourceTree = "<group>"; };
-		F242671BEF9F47004BD4AEA6994ACB6B /* GAIFields.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = GAIFields.h; path = Headers/Public/GAIFields.h; sourceTree = "<group>"; };
-		F2848ECE86915EED9032636E866D125F /* SPTSharedExampleGroups.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SPTSharedExampleGroups.m; path = Specta/Specta/SPTSharedExampleGroups.m; sourceTree = "<group>"; };
-		F3165B876D08CD102EA891025959EB19 /* EXPDoubleTuple.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = EXPDoubleTuple.m; path = Expecta/EXPDoubleTuple.m; sourceTree = "<group>"; };
-		F39B31E5EECC1F9DF23BDFF4244FE860 /* Pods-Segment-GoogleAnalytics_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Segment-GoogleAnalytics_Tests-resources.sh"; sourceTree = "<group>"; };
-		F7DE9BBD243370BF8EFFF25D7E85CD4C /* SEGGoogleAnalyticsIntegration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = SEGGoogleAnalyticsIntegration.h; sourceTree = "<group>"; };
-		FAE4AA155A2514A44DCF02CDE86885CF /* EXPMatchers+haveCountOf.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+haveCountOf.h"; path = "Expecta/Matchers/EXPMatchers+haveCountOf.h"; sourceTree = "<group>"; };
-		FCF10D4D8159FFF95CFCDB62577AA8E4 /* SEGPayload.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = SEGPayload.m; path = Pod/Classes/Integrations/SEGPayload.m; sourceTree = "<group>"; };
-		FE99B615AB863FEF83FD39F59E2A939D /* EXPMatchers+raise.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "EXPMatchers+raise.h"; path = "Expecta/Matchers/EXPMatchers+raise.h"; sourceTree = "<group>"; };
-		FF44A189D47E0B1CB7FA13DE72A685BB /* EXPMatchers+match.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "EXPMatchers+match.m"; path = "Expecta/Matchers/EXPMatchers+match.m"; sourceTree = "<group>"; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		199EF76AC47B3EE9FA80BE53835AB7B1 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				66081D3480D1FA028C4DE2344BF616D4 /* Foundation.framework in Frameworks */,
-				69363A59A4E2FF95D6A62AA88641A20A /* XCTest.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		25B28C645D7048EE8533D648851B36DE /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				CBC8E95BD4789904887E8E44506F2E19 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		7220860A5419A2390473421A11D2A3A0 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				91716783ABA4BA9B79B0501A0CDB59D9 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		915945EFDF699B928B3BE5F473CDA320 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				503BF36CDAFC3DE4E6862924EFF5DF1D /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DE3FAE515E840D135753AFEE65CCA8A8 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				FBBEEFC1F77A002E76A2E9CBC801BABF /* Foundation.framework in Frameworks */,
-				F9F824608D10EAF566AE7C2C9AD73CC5 /* XCTest.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EFC467B0EE8E1392E489559EAD8220D2 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DDA0131B5E07737BB02250EC8E73A2F6 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		08CD059C7FF78A67CA091A2E3008FDDF /* Analytics */ = {
-			isa = PBXGroup;
-			children = (
-				1638149FA560B7ED8704012F6E32B010 /* SEGAliasPayload.h */,
-				AA87D29C4C4D9CB70A5BB9010C93E406 /* SEGAliasPayload.m */,
-				CFAE41FD7F6F5C7D8E508C03208FFF59 /* SEGAnalytics.h */,
-				91A2E492978527A73B3C4C3DD6B91C97 /* SEGAnalytics.m */,
-				2837272F75DD845EF2A91B94FA9E38AA /* SEGAnalyticsRequest.h */,
-				CA511D8C5CCB276C4F4E948BD4A5939F /* SEGAnalyticsRequest.m */,
-				8C65EAD9F4779A546336645EC8E51355 /* SEGAnalyticsUtils.h */,
-				11DDFBEEBD749A88975C8606A445C015 /* SEGAnalyticsUtils.m */,
-				9317CA06C334C88F084CD88BF04618ED /* SEGBluetooth.h */,
-				4C1CE6534A62FA634E7867F189D282C2 /* SEGBluetooth.m */,
-				97F182F971933BFEF29A646F7D22423E /* SEGGroupPayload.h */,
-				52C7898921A306F30450C3679C050D2A /* SEGGroupPayload.m */,
-				8857DA884D845E55149E2D0721FE2C41 /* SEGIdentifyPayload.h */,
-				1701C01002B6CA774E41013BCDCF6F72 /* SEGIdentifyPayload.m */,
-				C6B2685864B008D5854B7554B05FE815 /* SEGIntegration.h */,
-				2E0733A0038EE5736FF18B5A63792DA6 /* SEGIntegrationFactory.h */,
-				D1CB69C27633FCC3576F1778EFC09B7D /* SEGLocation.h */,
-				2C9CEECF04FC9560D547C3380931D78B /* SEGLocation.m */,
-				0D32FAD33571B227BE06BBB6E80444A8 /* SEGPayload.h */,
-				FCF10D4D8159FFF95CFCDB62577AA8E4 /* SEGPayload.m */,
-				6BD6385C8632CDBB33C3F694D32D44AC /* SEGReachability.h */,
-				81B495005EBD1E18D49D930C9F0DE1A4 /* SEGReachability.m */,
-				231B198CBFD8DDBEF36D16F274FC83AE /* SEGScreenPayload.h */,
-				5A5D0FD313A4B5E5A78C8A34A9B71607 /* SEGScreenPayload.m */,
-				7ED4DAD1A4FB242A6CE917329C32BDCB /* SEGSegmentIntegration.h */,
-				7669417A2998C97CD154ABD987C5334E /* SEGSegmentIntegration.m */,
-				3ABC5E4B4982D08ED7380A4C08E3418C /* SEGSegmentIntegrationFactory.h */,
-				A35484475812F6496D912E772717EE78 /* SEGSegmentIntegrationFactory.m */,
-				3AD7BB555A10EBB24F11166027FCCB24 /* SEGTrackPayload.h */,
-				D99400BFB9A624D8E051FED7A1BDF315 /* SEGTrackPayload.m */,
-				F711FE6DE60FD2ED5D589F9C3262A6F3 /* Support Files */,
-			);
-			path = Analytics;
-			sourceTree = "<group>";
-		};
-		0C6B012983F9FEF8CC65C1318F5F090C /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				E351727CD07BB90B2A3CAE2C2433F6C5 /* Foundation.framework */,
-				279AA6492631DEFA8C439A9C088EEB8A /* XCTest.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		14327F0AB7B3F21ADB2B69A7DCA9CAF8 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				08CD059C7FF78A67CA091A2E3008FDDF /* Analytics */,
-				D7A891CE610ABA3D2BD4D00D054B959D /* Expecta */,
-				39E8D2657CF189783B72B6EFFA51ABAF /* GoogleAnalytics */,
-				3D93154BBE7C924F2D97D53D2E80C80E /* GoogleIDFASupport */,
-				5A9F6CCBF5079AF61D9D0249A7C2B9C0 /* Specta */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
-		1A6546EF89124663B2E4A520D1C2CA20 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				A8ABFA4EFC8E5E19332345AE253640A0 /* libAdIdAccessLibrary.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		207058C172433AEE54F3D861929C009B /* Segment-GoogleAnalytics */ = {
-			isa = PBXGroup;
-			children = (
-				56CAFEE86D5B03E4EC14D45E00544678 /* Pod */,
-				C455239AD9C4D14DE61DD20A51A59635 /* Support Files */,
-			);
-			name = "Segment-GoogleAnalytics";
-			path = ../..;
-			sourceTree = "<group>";
-		};
-		26EDC865188F93E75C783CD41E307006 /* Pods-Segment-GoogleAnalytics_Example */ = {
-			isa = PBXGroup;
-			children = (
-				855FF2069FE35409211B068CF74D1BC9 /* Pods-Segment-GoogleAnalytics_Example-acknowledgements.markdown */,
-				9936109944D13524536A31583D20FC5C /* Pods-Segment-GoogleAnalytics_Example-acknowledgements.plist */,
-				98AF2EF29263F6E5F2917A01134D91A1 /* Pods-Segment-GoogleAnalytics_Example-dummy.m */,
-				A8BCFD4057C083FF8B2B91CAA2A517AD /* Pods-Segment-GoogleAnalytics_Example-frameworks.sh */,
-				B9ADDA29B749820D119249DA1929589E /* Pods-Segment-GoogleAnalytics_Example-resources.sh */,
-				C6ABA54126ECDD4523DA27371E0E9474 /* Pods-Segment-GoogleAnalytics_Example.debug.xcconfig */,
-				D0B9C9663686AD4EC06FA9062E80A8F0 /* Pods-Segment-GoogleAnalytics_Example.release.xcconfig */,
-			);
-			name = "Pods-Segment-GoogleAnalytics_Example";
-			path = "Target Support Files/Pods-Segment-GoogleAnalytics_Example";
-			sourceTree = "<group>";
-		};
-		39E8D2657CF189783B72B6EFFA51ABAF /* GoogleAnalytics */ = {
-			isa = PBXGroup;
-			children = (
-				CCDE6708F49E9734E245E14F26FEC611 /* GAI.h */,
-				0D99CDFBEB811EE97A2EE7BD42C8C872 /* GAIDictionaryBuilder.h */,
-				E9E5EFF4A45283579A977D61C2FEE50C /* GAIEcommerceFields.h */,
-				8DDB38718F95D76871BD12B66C61FB29 /* GAIEcommerceProduct.h */,
-				4A023A20387157632011915438018BA0 /* GAIEcommerceProductAction.h */,
-				9F56505149E55909F48A9E238EC226EC /* GAIEcommercePromotion.h */,
-				F242671BEF9F47004BD4AEA6994ACB6B /* GAIFields.h */,
-				CF6E7D5EB1BE0988C685F173F5871BC8 /* GAILogger.h */,
-				147BB6B93BF01AB27D7C213F8FFC0F0A /* GAITrackedViewController.h */,
-				803929AB0EC5B999F71365235E2FC569 /* GAITracker.h */,
-				9F4BA3995289C6236CF8558CE17CD670 /* Frameworks */,
-			);
-			path = GoogleAnalytics;
-			sourceTree = "<group>";
-		};
-		3D93154BBE7C924F2D97D53D2E80C80E /* GoogleIDFASupport */ = {
-			isa = PBXGroup;
-			children = (
-				1A6546EF89124663B2E4A520D1C2CA20 /* Frameworks */,
-			);
-			path = GoogleIDFASupport;
-			sourceTree = "<group>";
-		};
-		433CD3331B6C3787F473C941B61FC68F /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				0C6B012983F9FEF8CC65C1318F5F090C /* iOS */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		44727FC65C18BECDF363D9F7AE53FC15 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				C0243D80A39E6D84988415B3206EBCF0 /* libAnalytics.a */,
-				1BB5FCB799A3E132B5FAA78FAF5AD39C /* libExpecta.a */,
-				D58B97E6820E236C055063572F1E32A2 /* libPods-Segment-GoogleAnalytics_Example.a */,
-				986E88CA93CED9C4B4963349457B2AA8 /* libPods-Segment-GoogleAnalytics_Tests.a */,
-				41DDF8C028B6E5026AD5CC5BAD2AAA3B /* libSegment-GoogleAnalytics.a */,
-				8811C2CFB32EDC145242E31D1D6000C3 /* libSpecta.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		56CAFEE86D5B03E4EC14D45E00544678 /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				98DF4A3BC1F64C0C071727A6031AF527 /* Classes */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		5A9F6CCBF5079AF61D9D0249A7C2B9C0 /* Specta */ = {
-			isa = PBXGroup;
-			children = (
-				7C1E9D81E228F9B07251DEEB275F4744 /* Specta.h */,
-				4511AE2A42381FF1A3B3C12144FC0C0E /* SpectaDSL.h */,
-				C1C171166E9393E8C112CDC72CDEBF13 /* SpectaDSL.m */,
-				7146A0979739F3A21FF50C0953C8D2A0 /* SpectaTypes.h */,
-				7FD3BC43A6C31A97BF932D9F18311E76 /* SpectaUtility.h */,
-				568C2BF10FCA51F625ECC214C3A9D520 /* SpectaUtility.m */,
-				789F69996FFDE3AECA5AF9C317B256B6 /* SPTCallSite.h */,
-				76948DA1B8E447BB5BAEBFBBF91D38EF /* SPTCallSite.m */,
-				67D33B9C02CA7DFBF73919E3CE31AD7A /* SPTCompiledExample.h */,
-				20931BF25C1C314AD48793C2B3EFB1DD /* SPTCompiledExample.m */,
-				D327A699D86B9304B2D3FEAB534333DC /* SPTExample.h */,
-				9A3BD1002DD3D3877A0AD6DC83B9AFC7 /* SPTExample.m */,
-				56F3B4B2BD22271258A1CB037C17CF99 /* SPTExampleGroup.h */,
-				6807539CEC31F5EB61DC3B93ADD174C7 /* SPTExampleGroup.m */,
-				1ECBFFA672D10773C52B801D99B88FBE /* SPTExcludeGlobalBeforeAfterEach.h */,
-				203F34C34A866E23F7B4CF5C17CA8EA5 /* SPTGlobalBeforeAfterEach.h */,
-				3756FB16CD0261AA42611CD5D01B88C7 /* SPTSharedExampleGroups.h */,
-				F2848ECE86915EED9032636E866D125F /* SPTSharedExampleGroups.m */,
-				41D48B8BD24D516FA56686BDD2A113C2 /* SPTSpec.h */,
-				5400AA6F166FE7EE163E4966C6466D21 /* SPTSpec.m */,
-				B658C2B4FB8A46E92A154CFF1291537A /* SPTTestSuite.h */,
-				66266AC3D90E76C93DFDBE52120305BE /* SPTTestSuite.m */,
-				55345A779F22C7147507AC695CE3B85B /* XCTest+Private.h */,
-				27B1B54BB2BA7B78455DCEB2FEF70BC6 /* XCTestCase+Specta.h */,
-				AAAFAFFB150A80628C686DDD8D642B9D /* XCTestCase+Specta.m */,
-				D6E18A324EC0EBA79E68C000D042CCB0 /* Support Files */,
-			);
-			path = Specta;
-			sourceTree = "<group>";
-		};
-		6D00BA5555F1E5B354F14BDC1A0274B9 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				1DB0E1341AF1923C7D66E6695062860B /* Expecta.xcconfig */,
-				22F3505207F93C01E28757C157D01EEB /* Expecta-dummy.m */,
-				0B89D65F93B8B964E748359C59731131 /* Expecta-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Expecta";
-			sourceTree = "<group>";
-		};
-		6EAF2E95795D983AC7CE49F822DA3827 /* Development Pods */ = {
-			isa = PBXGroup;
-			children = (
-				207058C172433AEE54F3D861929C009B /* Segment-GoogleAnalytics */,
-			);
-			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		7DB346D0F39D3F0E887471402A8071AB = {
-			isa = PBXGroup;
-			children = (
-				BA6428E9F66FD5A23C0A2E06ED26CD2F /* Podfile */,
-				6EAF2E95795D983AC7CE49F822DA3827 /* Development Pods */,
-				433CD3331B6C3787F473C941B61FC68F /* Frameworks */,
-				14327F0AB7B3F21ADB2B69A7DCA9CAF8 /* Pods */,
-				44727FC65C18BECDF363D9F7AE53FC15 /* Products */,
-				E1611D850FB6C6C54941631CDAB3A5A7 /* Targets Support Files */,
-			);
-			sourceTree = "<group>";
-		};
-		98DF4A3BC1F64C0C071727A6031AF527 /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				F7DE9BBD243370BF8EFFF25D7E85CD4C /* SEGGoogleAnalyticsIntegration.h */,
-				1090ADEE4E406645BC0603EF794F19AE /* SEGGoogleAnalyticsIntegration.m */,
-				51F974C6782C68F90D278FCEA769A59E /* SEGGoogleAnalyticsIntegrationFactory.h */,
-				99AF585D638505D532A2B91329682F8E /* SEGGoogleAnalyticsIntegrationFactory.m */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
-		99BD68DAAEB1D209D3294D30352A9B1C /* Pods-Segment-GoogleAnalytics_Tests */ = {
-			isa = PBXGroup;
-			children = (
-				4F399E73BB1F0DA1C2966C111EA9C7EE /* Pods-Segment-GoogleAnalytics_Tests-acknowledgements.markdown */,
-				00AA78757DDCD095BADCC948F96D9918 /* Pods-Segment-GoogleAnalytics_Tests-acknowledgements.plist */,
-				666C57509FA1B9FD91574E36B4521896 /* Pods-Segment-GoogleAnalytics_Tests-dummy.m */,
-				067AB382C6EAF94F9525C2D3E798EA89 /* Pods-Segment-GoogleAnalytics_Tests-frameworks.sh */,
-				F39B31E5EECC1F9DF23BDFF4244FE860 /* Pods-Segment-GoogleAnalytics_Tests-resources.sh */,
-				E200A1F712D8C70CEE0ABE0ACDE4D904 /* Pods-Segment-GoogleAnalytics_Tests.debug.xcconfig */,
-				CAAE62E8DB86653476BDEDF0B6664DBD /* Pods-Segment-GoogleAnalytics_Tests.release.xcconfig */,
-			);
-			name = "Pods-Segment-GoogleAnalytics_Tests";
-			path = "Target Support Files/Pods-Segment-GoogleAnalytics_Tests";
-			sourceTree = "<group>";
-		};
-		9F4BA3995289C6236CF8558CE17CD670 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				74D3ACC6B6BEF1EDD07AE51CA1B7E60D /* libGoogleAnalytics.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		C455239AD9C4D14DE61DD20A51A59635 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				9E7AED6529044F5A3F1798885FA0EB66 /* Segment-GoogleAnalytics.xcconfig */,
-				D671DB178CE02AEA19CBF062C3596692 /* Segment-GoogleAnalytics-dummy.m */,
-				04CCA4E932E4555FE104E08F5A1F899A /* Segment-GoogleAnalytics-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "Example/Pods/Target Support Files/Segment-GoogleAnalytics";
-			sourceTree = "<group>";
-		};
-		D6E18A324EC0EBA79E68C000D042CCB0 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				003E1FF25B624503C0B7DE8E09FFCD2E /* Specta.xcconfig */,
-				EEA295B5F005DA5BE3281CE44E4D995D /* Specta-dummy.m */,
-				578995B5D7A1B89485396FD3F985F3C1 /* Specta-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Specta";
-			sourceTree = "<group>";
-		};
-		D7A891CE610ABA3D2BD4D00D054B959D /* Expecta */ = {
-			isa = PBXGroup;
-			children = (
-				463DA29EAC33AE0F642267ADB9876178 /* EXPBlockDefinedMatcher.h */,
-				C1A93C3D14968665C68BD6069241F78C /* EXPBlockDefinedMatcher.m */,
-				195673BC1D4EBD3D604A447FFEF80200 /* EXPDefines.h */,
-				B4B89A8180E266D6FD109356EBE762DA /* EXPDoubleTuple.h */,
-				F3165B876D08CD102EA891025959EB19 /* EXPDoubleTuple.m */,
-				661A7213AFBB8E769759DBE86DCAE8EB /* Expecta.h */,
-				E128AD4B837926B3A5A036D8E8DFECAD /* ExpectaObject.h */,
-				90652227DA6C2B4C6C8E843F2F8BAC21 /* ExpectaObject.m */,
-				6A1C939D28292C3A5B4011F361790762 /* ExpectaSupport.h */,
-				C258607F1A902F6E3358877275B1C45D /* ExpectaSupport.m */,
-				EDB92F0DECBE15130358426D5213D6C8 /* EXPExpect.h */,
-				0D61BFA15E780468CFF692FA8FFE5AFE /* EXPExpect.m */,
-				56BBCF71F950D6191CD6B1B91A85FA82 /* EXPFloatTuple.h */,
-				2743254252516E0A88873C5402573C5B /* EXPFloatTuple.m */,
-				DE73CB6561F92F5CB79F28F7A4303749 /* EXPMatcher.h */,
-				305B6661988E84D5D0C3B158B277BEAC /* EXPMatcherHelpers.h */,
-				E3554BD7A107F9879E5EB62B4F8C2A35 /* EXPMatcherHelpers.m */,
-				03F690173163BA691C98E1D242100544 /* EXPMatchers.h */,
-				4C84E03C3810D3CB1B6F36216A398A2E /* EXPMatchers+beCloseTo.h */,
-				86F591E03C6A2C071821D67283CFF54D /* EXPMatchers+beCloseTo.m */,
-				C4E98ABEAC39F16F3D1D5D53F15A2F9F /* EXPMatchers+beFalsy.h */,
-				4D12FAE56109712094DA78D38B05DA2C /* EXPMatchers+beFalsy.m */,
-				22FAD7D819C780BD3941E8361C9DE50E /* EXPMatchers+beginWith.h */,
-				C582A29AB08E63C474831C4D63A9B123 /* EXPMatchers+beginWith.m */,
-				C57F3C0E6485F86FF3B4BBF6323AA0F2 /* EXPMatchers+beGreaterThan.h */,
-				17A3F1607267A4CD0D8B76C017299F78 /* EXPMatchers+beGreaterThan.m */,
-				C9E85A65EFBEA8CB9F441C68B3E492C1 /* EXPMatchers+beGreaterThanOrEqualTo.h */,
-				518A7131AD41523DC00501D702A1EF88 /* EXPMatchers+beGreaterThanOrEqualTo.m */,
-				2E91479DE86808F686A59942FC879D8E /* EXPMatchers+beIdenticalTo.h */,
-				5A2F6E1360B9C61485920F5D5473A974 /* EXPMatchers+beIdenticalTo.m */,
-				A9B2D68316EF35682E3B24DD33C44B66 /* EXPMatchers+beInstanceOf.h */,
-				90552A900C20BA732E285A6C8CDB4660 /* EXPMatchers+beInstanceOf.m */,
-				0632D8C7A85E2AB40699726F5382E847 /* EXPMatchers+beInTheRangeOf.h */,
-				3E4490F950B5EC6EAC20E6BD37E9C14E /* EXPMatchers+beInTheRangeOf.m */,
-				8A96A585C0DF065295FEE69BB53944E9 /* EXPMatchers+beKindOf.h */,
-				C90EFAB73AD4A25DD1A311ACFB030AE8 /* EXPMatchers+beKindOf.m */,
-				2494E91B1F913E639B70B22D66D6B52F /* EXPMatchers+beLessThan.h */,
-				2C9B4D847287245CC715A02DD0F307E1 /* EXPMatchers+beLessThan.m */,
-				EC523F5B18127D76F5586636012C547F /* EXPMatchers+beLessThanOrEqualTo.h */,
-				0230190DDFC91DA732D8624EF3C54A9E /* EXPMatchers+beLessThanOrEqualTo.m */,
-				4DC954F6F5AB56AE2D793E9ACA45624D /* EXPMatchers+beNil.h */,
-				4075E3A20D226B9478030380B33E3EEE /* EXPMatchers+beNil.m */,
-				6A2147C8C8E0A818D9BC42DC2F23709B /* EXPMatchers+beSubclassOf.h */,
-				C86EDDCE44ACD911BBDB34FA398F8A83 /* EXPMatchers+beSubclassOf.m */,
-				95513FEBF6B22034689515724F049996 /* EXPMatchers+beSupersetOf.h */,
-				ED4F564CFDAA4CBE9BBFBECE5695AA05 /* EXPMatchers+beSupersetOf.m */,
-				8B073B349D98A4F02811E8A0E77D58BC /* EXPMatchers+beTruthy.h */,
-				8AF5B07DCDCBE1BC22042D777A38B464 /* EXPMatchers+beTruthy.m */,
-				2D88ACEFC22E13FCF6F27A591CCC1D53 /* EXPMatchers+conformTo.h */,
-				A1FCE77270936EE316746356E3A413E1 /* EXPMatchers+conformTo.m */,
-				76FDA2EF06A82D029BE55F779402A351 /* EXPMatchers+contain.h */,
-				A76D476E5FC248FFF04B019CFE53E21A /* EXPMatchers+contain.m */,
-				8499D866C1900FB26A437C8FE263DB5E /* EXPMatchers+endWith.h */,
-				61D10D4273167662735D83D780C56F89 /* EXPMatchers+endWith.m */,
-				90A6E1569ECE25A96D932D7CB0456A00 /* EXPMatchers+equal.h */,
-				277DE8AADE10662CAE402205802458BA /* EXPMatchers+equal.m */,
-				FAE4AA155A2514A44DCF02CDE86885CF /* EXPMatchers+haveCountOf.h */,
-				79C247F75A75B96048791BEBE10B0B03 /* EXPMatchers+haveCountOf.m */,
-				39E9492F7292B43EF5DE6007F51DA0EC /* EXPMatchers+match.h */,
-				FF44A189D47E0B1CB7FA13DE72A685BB /* EXPMatchers+match.m */,
-				8DC6005FC38AC1939F82F6C1FB9A2E36 /* EXPMatchers+postNotification.h */,
-				19BA3A4E9AB74D50BA74D05C5A3A497B /* EXPMatchers+postNotification.m */,
-				FE99B615AB863FEF83FD39F59E2A939D /* EXPMatchers+raise.h */,
-				799B3B17E7D0BC474B86DA58267CBEE4 /* EXPMatchers+raise.m */,
-				DE132C2A739AD46783858B794AD9EEEA /* EXPMatchers+raiseWithReason.h */,
-				80C8D930FC5B078021D346DAB2B72B81 /* EXPMatchers+raiseWithReason.m */,
-				A5040B544FBFCCA344AF6F5D7ADDFADF /* EXPMatchers+respondTo.h */,
-				4F7810CA7C3360CA27786A4189D1F13A /* EXPMatchers+respondTo.m */,
-				869F6CDA9DFD53454C106CBA668F580E /* EXPUnsupportedObject.h */,
-				66A04F37AA8446E5F76E605B220607FA /* EXPUnsupportedObject.m */,
-				EF3EB8C9DCBBEF065C7190483B798529 /* NSObject+Expecta.h */,
-				BDA0B809F5CE67054059064E81CBAF5F /* NSValue+Expecta.h */,
-				5F5D27B4777037698149BC2D9793405F /* NSValue+Expecta.m */,
-				6D00BA5555F1E5B354F14BDC1A0274B9 /* Support Files */,
-			);
-			path = Expecta;
-			sourceTree = "<group>";
-		};
-		E1611D850FB6C6C54941631CDAB3A5A7 /* Targets Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				26EDC865188F93E75C783CD41E307006 /* Pods-Segment-GoogleAnalytics_Example */,
-				99BD68DAAEB1D209D3294D30352A9B1C /* Pods-Segment-GoogleAnalytics_Tests */,
-			);
-			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		F711FE6DE60FD2ED5D589F9C3262A6F3 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				558A49FF40959AE7147F14C765269D33 /* Analytics.xcconfig */,
-				CBFEA0C6D4EBA470E98B90635BAB38B2 /* Analytics-dummy.m */,
-				2FC2FBF5CAFA206F9C92EC6A22AC0B84 /* Analytics-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Analytics";
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXHeadersBuildPhase section */
-		191BD56D6E43E54A25DA0A5C308A2752 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				49496209C5711E0D5A4A51DCF8FB8DEC /* SEGGoogleAnalyticsIntegration.h in Headers */,
-				C345B90819C4CE033B07926CFEEF9644 /* SEGGoogleAnalyticsIntegrationFactory.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		A0599526CEAEE33A2D986C0B1B06A949 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				2D881B10160E6AA5B265F69CA2F53159 /* Specta.h in Headers */,
-				CCCD4FA4F4339DED24A487A9312D9526 /* SpectaDSL.h in Headers */,
-				475BBFA6E99B39CB8429C0B71972E445 /* SpectaTypes.h in Headers */,
-				D3C948582E14C4F4A6D87738C5EB0EC1 /* SpectaUtility.h in Headers */,
-				F40B16934B552AC428855EC01D39473C /* SPTCallSite.h in Headers */,
-				6656F35498E5573ED9F890D8B828B828 /* SPTCompiledExample.h in Headers */,
-				DA51317333A94F4A9B3B1FF0A1DF71EF /* SPTExample.h in Headers */,
-				43659A5034D2F6C8510DDC52EFD7B7CA /* SPTExampleGroup.h in Headers */,
-				70F1E51CF39B72EA90BB9F19C3056733 /* SPTExcludeGlobalBeforeAfterEach.h in Headers */,
-				4B0EA949E5076B09ED0B24C22053F953 /* SPTGlobalBeforeAfterEach.h in Headers */,
-				3D508F6B13170EC5036ECEEECB475BA4 /* SPTSharedExampleGroups.h in Headers */,
-				C186082DC500722CB26121EAB9F92126 /* SPTSpec.h in Headers */,
-				605CADFBD63A01EDAA5A251B60B2C6AA /* SPTTestSuite.h in Headers */,
-				B7D89DBEEF4C2A2165C2A1E127947D9A /* XCTest+Private.h in Headers */,
-				2CDDCDCA361D583C58B28EF022F8387E /* XCTestCase+Specta.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		C6AD7852D34E8A80DFF3B8376BDE812F /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8DF90D623F7F9015EEE9F1D7FEE7E053 /* EXPBlockDefinedMatcher.h in Headers */,
-				6A4E3ACA285A21392936C110E7EC91F0 /* EXPDefines.h in Headers */,
-				3A013F13122CDB8EE962F8CB7C6FCC8E /* EXPDoubleTuple.h in Headers */,
-				A6854D311D55E2BBD8BFCE4E82DF3EA9 /* Expecta.h in Headers */,
-				081F2104425CDCB0915354E2FBD7E24E /* ExpectaObject.h in Headers */,
-				7AC91F55DAAA2F0223A97BEFF8BCAF68 /* ExpectaSupport.h in Headers */,
-				2A17721E4A81DB608CA6D4FB6F0ADAFB /* EXPExpect.h in Headers */,
-				341D7536159B52F41598F730CC45D548 /* EXPFloatTuple.h in Headers */,
-				07282695806D1DFBF187BFA004D80641 /* EXPMatcher.h in Headers */,
-				A8490A46CB5206BCA5F90FCFBA2D731E /* EXPMatcherHelpers.h in Headers */,
-				AA7B402D31D86AE5E3DD083408311FF1 /* EXPMatchers+beCloseTo.h in Headers */,
-				F4CA468B5A9F8FF2A4DB8B236A8E71BF /* EXPMatchers+beFalsy.h in Headers */,
-				021C50274FF43A6F07E119D572C3ACB6 /* EXPMatchers+beginWith.h in Headers */,
-				8F674582EE71972EE60EFD96C1F173D5 /* EXPMatchers+beGreaterThan.h in Headers */,
-				3E463E2B6917D9AA08A03BA8A8E74A18 /* EXPMatchers+beGreaterThanOrEqualTo.h in Headers */,
-				AB1D6408D48F6ECF3FCE553BE73961F5 /* EXPMatchers+beIdenticalTo.h in Headers */,
-				D42799488F38F2DB8A580730CEE13CE6 /* EXPMatchers+beInstanceOf.h in Headers */,
-				97E91EC237B8623D895DBF6092034AD7 /* EXPMatchers+beInTheRangeOf.h in Headers */,
-				9B546D0F895D9B5A8316B948CEE95C77 /* EXPMatchers+beKindOf.h in Headers */,
-				DFF580AE359407E841BA8D8DDCE6E299 /* EXPMatchers+beLessThan.h in Headers */,
-				EE52A320EC3155B114104E06396D1B59 /* EXPMatchers+beLessThanOrEqualTo.h in Headers */,
-				74707D5ABEC55B3084F52C40A4227B06 /* EXPMatchers+beNil.h in Headers */,
-				14C609D8F203FD45194E93997EFF744E /* EXPMatchers+beSubclassOf.h in Headers */,
-				9019F9233E2A8B04A82C1B8D0274F09F /* EXPMatchers+beSupersetOf.h in Headers */,
-				70545E4EA86C6E593A2A9F6731DA8F6D /* EXPMatchers+beTruthy.h in Headers */,
-				2945FAA75C956DD6A541EB51E42E6899 /* EXPMatchers+conformTo.h in Headers */,
-				02C7E3EC1E1DFDD7046BD26A67E92686 /* EXPMatchers+contain.h in Headers */,
-				76331E71086C8CD5118A69B046D8F0FB /* EXPMatchers+endWith.h in Headers */,
-				430CE433DB59FE090A8CC6AFCFA43337 /* EXPMatchers+equal.h in Headers */,
-				237FB063FB365119546C7B5006224F3B /* EXPMatchers+haveCountOf.h in Headers */,
-				C98F5401E5C1AB6512BE50C3B7CEA9BF /* EXPMatchers+match.h in Headers */,
-				339A0C1BFF72397A705959E03877DDDB /* EXPMatchers+postNotification.h in Headers */,
-				AAE75938ED3DD46BC00352B82D7CA890 /* EXPMatchers+raise.h in Headers */,
-				6EB2498C2AFB1DF8555CB7C1EF89CA5C /* EXPMatchers+raiseWithReason.h in Headers */,
-				E867CBF850D20C314BF4BD790432455D /* EXPMatchers+respondTo.h in Headers */,
-				6924E116731D7079958063A3EE0781ED /* EXPMatchers.h in Headers */,
-				4231743B6C143BDB4A5FBB032E6D3799 /* EXPUnsupportedObject.h in Headers */,
-				956FB3AB698AF3DA776A9F24AA79C229 /* NSObject+Expecta.h in Headers */,
-				60D3CCEB5B53542228790ABD8885AF42 /* NSValue+Expecta.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EFC9C5C646400A8B60584BB8E9857236 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E617E37B8DE4B930EC91E78E7B804A9C /* SEGAliasPayload.h in Headers */,
-				2F824EA28F819F2E4A9E6D31E14D0603 /* SEGAnalytics.h in Headers */,
-				98A22457F5E28CAF0B7E113A6D4142A1 /* SEGAnalyticsRequest.h in Headers */,
-				901C95FA513F8BEC6992EE457A527DE1 /* SEGAnalyticsUtils.h in Headers */,
-				539C2C0907CA46CC4DE78E19B1AFFA8E /* SEGBluetooth.h in Headers */,
-				F6A5E9881D67168D9B9BFA5FCD834596 /* SEGGroupPayload.h in Headers */,
-				EF305FCB32346C76431C1202E7AD467B /* SEGIdentifyPayload.h in Headers */,
-				25BBDA674BE9447D354412C79BF4B16C /* SEGIntegration.h in Headers */,
-				BC021CC978BE68B2BE0A690878FB54AF /* SEGIntegrationFactory.h in Headers */,
-				41D47B37FDEA46945606C39C44042D8C /* SEGLocation.h in Headers */,
-				B87904014217EC9142A60100E6D363E3 /* SEGPayload.h in Headers */,
-				DAC08D09C7E4411C8B01CD2FCFCD247B /* SEGReachability.h in Headers */,
-				6CBB0742821FD4D346404011AE148582 /* SEGScreenPayload.h in Headers */,
-				F280BEB32C116B6249D42E50A697B04B /* SEGSegmentIntegration.h in Headers */,
-				26FDD94D57A937677D2A42E53E7DBD7A /* SEGSegmentIntegrationFactory.h in Headers */,
-				DD7BED725086CF410512F736DE7AA95B /* SEGTrackPayload.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXHeadersBuildPhase section */
-
-/* Begin PBXNativeTarget section */
-		1752D706BA25FF27E5712204C17F8745 /* Pods-Segment-GoogleAnalytics_Example */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 3B24DD01561BA6B1F8D2B8C3F93630D7 /* Build configuration list for PBXNativeTarget "Pods-Segment-GoogleAnalytics_Example" */;
-			buildPhases = (
-				8559F319F13540B66A857B6CFF67836E /* Sources */,
-				915945EFDF699B928B3BE5F473CDA320 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				5379BFDE6004D230B23CB016EB03E197 /* PBXTargetDependency */,
-				6F219A4367F11919243ABEDBE901877C /* PBXTargetDependency */,
-			);
-			name = "Pods-Segment-GoogleAnalytics_Example";
-			productName = "Pods-Segment-GoogleAnalytics_Example";
-			productReference = D58B97E6820E236C055063572F1E32A2 /* libPods-Segment-GoogleAnalytics_Example.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		2F501FE84845EAD97B9087DAFCBBEE0E /* Expecta */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 57205495CF13B4EE93B13B7B0E3A1BD2 /* Build configuration list for PBXNativeTarget "Expecta" */;
-			buildPhases = (
-				143C0831AA95D723669324010D835391 /* Sources */,
-				199EF76AC47B3EE9FA80BE53835AB7B1 /* Frameworks */,
-				C6AD7852D34E8A80DFF3B8376BDE812F /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Expecta;
-			productName = Expecta;
-			productReference = 1BB5FCB799A3E132B5FAA78FAF5AD39C /* libExpecta.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		58EB5E47E144CBC4F4FE00C8F2B1AB95 /* Pods-Segment-GoogleAnalytics_Tests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 5FA20BA7A3A1E3F8092D2C94AFED6D76 /* Build configuration list for PBXNativeTarget "Pods-Segment-GoogleAnalytics_Tests" */;
-			buildPhases = (
-				0DB6AFFBA2CB5525D9780F1DE6FAB593 /* Sources */,
-				EFC467B0EE8E1392E489559EAD8220D2 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				77BE6CC9369C45EFBC1FD1A322BFD975 /* PBXTargetDependency */,
-				6DDC1EFBB7D02CDCC05FCF39C83AE2C9 /* PBXTargetDependency */,
-				ABF9EC2DB5BBC2E9086DA001DAFE23F0 /* PBXTargetDependency */,
-				1D79E234B869C1FA242E45E7DCB4A100 /* PBXTargetDependency */,
-			);
-			name = "Pods-Segment-GoogleAnalytics_Tests";
-			productName = "Pods-Segment-GoogleAnalytics_Tests";
-			productReference = 986E88CA93CED9C4B4963349457B2AA8 /* libPods-Segment-GoogleAnalytics_Tests.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		859E063BB03DDB2C5D9A99DB427478EA /* Segment-GoogleAnalytics */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = B1ABFB242198C5E38A6728EA931D52C8 /* Build configuration list for PBXNativeTarget "Segment-GoogleAnalytics" */;
-			buildPhases = (
-				F8A3174F1370ED9A57F94C3ED212C70E /* Sources */,
-				25B28C645D7048EE8533D648851B36DE /* Frameworks */,
-				191BD56D6E43E54A25DA0A5C308A2752 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				EFA2F8627C19B0786403860E75168CF4 /* PBXTargetDependency */,
-			);
-			name = "Segment-GoogleAnalytics";
-			productName = "Segment-GoogleAnalytics";
-			productReference = 41DDF8C028B6E5026AD5CC5BAD2AAA3B /* libSegment-GoogleAnalytics.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		9A7702F7DB899DC0B318CF2119620155 /* Specta */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D28FB9DCE5CE0170C17A7A54A9F819B3 /* Build configuration list for PBXNativeTarget "Specta" */;
-			buildPhases = (
-				16EC47C0D8BADA487C115973D26718A7 /* Sources */,
-				DE3FAE515E840D135753AFEE65CCA8A8 /* Frameworks */,
-				A0599526CEAEE33A2D986C0B1B06A949 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Specta;
-			productName = Specta;
-			productReference = 8811C2CFB32EDC145242E31D1D6000C3 /* libSpecta.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		E703EF8141AB3D56D46182B4EA5FB571 /* Analytics */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D69A20A8681184C1F18D69A2BB644717 /* Build configuration list for PBXNativeTarget "Analytics" */;
-			buildPhases = (
-				EF6D2DF45C8F0BE6ED157435C762B99A /* Sources */,
-				7220860A5419A2390473421A11D2A3A0 /* Frameworks */,
-				EFC9C5C646400A8B60584BB8E9857236 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Analytics;
-			productName = Analytics;
-			productReference = C0243D80A39E6D84988415B3206EBCF0 /* libAnalytics.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		D41D8CD98F00B204E9800998ECF8427E /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
-			};
-			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-			);
-			mainGroup = 7DB346D0F39D3F0E887471402A8071AB;
-			productRefGroup = 44727FC65C18BECDF363D9F7AE53FC15 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				E703EF8141AB3D56D46182B4EA5FB571 /* Analytics */,
-				2F501FE84845EAD97B9087DAFCBBEE0E /* Expecta */,
-				1752D706BA25FF27E5712204C17F8745 /* Pods-Segment-GoogleAnalytics_Example */,
-				58EB5E47E144CBC4F4FE00C8F2B1AB95 /* Pods-Segment-GoogleAnalytics_Tests */,
-				859E063BB03DDB2C5D9A99DB427478EA /* Segment-GoogleAnalytics */,
-				9A7702F7DB899DC0B318CF2119620155 /* Specta */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXSourcesBuildPhase section */
-		0DB6AFFBA2CB5525D9780F1DE6FAB593 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6FF568E538D78F99F2EA1ED159B99766 /* Pods-Segment-GoogleAnalytics_Tests-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		143C0831AA95D723669324010D835391 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				CF95446EA555B49150EA7270096D78B2 /* EXPBlockDefinedMatcher.m in Sources */,
-				487899F028C39C1A518547A1AB2F625A /* EXPDoubleTuple.m in Sources */,
-				FDF72740DBC37AFACFED73ED42282383 /* Expecta-dummy.m in Sources */,
-				11CF0C44A36897A963C15B74C2AEC415 /* ExpectaObject.m in Sources */,
-				4383E0DB1B07B9EB3155EF5D5F27C7BA /* ExpectaSupport.m in Sources */,
-				104AFE24D01F1C4495926B40B53C5945 /* EXPExpect.m in Sources */,
-				779CFE8771E1EF63F1313ABEBCECAA4A /* EXPFloatTuple.m in Sources */,
-				49EFE75BAF060A33327F3CE8C18436F2 /* EXPMatcherHelpers.m in Sources */,
-				5F6D96E64F890BDC4A75B73C3D50A0DD /* EXPMatchers+beCloseTo.m in Sources */,
-				F1F4E65611F5567A86AF797EAC3E225B /* EXPMatchers+beFalsy.m in Sources */,
-				A7141BC83638F4B38D4D312BAE3BDAC4 /* EXPMatchers+beginWith.m in Sources */,
-				CB08C9C83ABDBE55762A423ED48491EF /* EXPMatchers+beGreaterThan.m in Sources */,
-				AD6791D14732A3C17164F61CC72FFB0D /* EXPMatchers+beGreaterThanOrEqualTo.m in Sources */,
-				A65C491577A425AF82C53F4A40A0A24B /* EXPMatchers+beIdenticalTo.m in Sources */,
-				2F9D3747596E4E074C3B776949091047 /* EXPMatchers+beInstanceOf.m in Sources */,
-				7436C602BB1CA7C91560C28DE749357B /* EXPMatchers+beInTheRangeOf.m in Sources */,
-				63D0CD4F0FB5A6103E1DDB46E876CBB6 /* EXPMatchers+beKindOf.m in Sources */,
-				C6671739E8C5904113586F8BEBBC9780 /* EXPMatchers+beLessThan.m in Sources */,
-				43A1104CA0C628C2F693902EADA32B8C /* EXPMatchers+beLessThanOrEqualTo.m in Sources */,
-				E06376455C1D5E45B97ACDC5438FC15B /* EXPMatchers+beNil.m in Sources */,
-				BD30B724A71CF5D6E93805B7615EC79C /* EXPMatchers+beSubclassOf.m in Sources */,
-				6D37BEAA1FC469C3582CACB4E9766502 /* EXPMatchers+beSupersetOf.m in Sources */,
-				5E8F33E777456DA63CA2D902508A9058 /* EXPMatchers+beTruthy.m in Sources */,
-				C2BFF99EB859FD7056CF72C4850693D1 /* EXPMatchers+conformTo.m in Sources */,
-				46F312CBB94BAE62B58D3D7AE28E8DBD /* EXPMatchers+contain.m in Sources */,
-				B33234F432A72D5E8B65694AE937B78F /* EXPMatchers+endWith.m in Sources */,
-				8059E5674B08670B0A002D564FFABF44 /* EXPMatchers+equal.m in Sources */,
-				562BE99A6F630E709218EB9B3CF36E90 /* EXPMatchers+haveCountOf.m in Sources */,
-				2239B5E63C5D2C1323D66F489F075C42 /* EXPMatchers+match.m in Sources */,
-				69EBB956302554EA37775F4D806BC4DD /* EXPMatchers+postNotification.m in Sources */,
-				7FEE0E8D094D7BCCAC7129473EE05ADC /* EXPMatchers+raise.m in Sources */,
-				A26F992E8831118311F3DB7CB830595A /* EXPMatchers+raiseWithReason.m in Sources */,
-				E2EBD18BA89D3FF648947DF31FA12D44 /* EXPMatchers+respondTo.m in Sources */,
-				40F505E69B8595361C2A7528DDA222B6 /* EXPUnsupportedObject.m in Sources */,
-				872948DAF79618AD725E0BF364E5DDD4 /* NSValue+Expecta.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		16EC47C0D8BADA487C115973D26718A7 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				50479B6EF1A2C74265F5AB553CFC56F2 /* Specta-dummy.m in Sources */,
-				E8D41CF69BC7D498C16F3887A021F4BA /* SpectaDSL.m in Sources */,
-				9F4084E6D71859700239E620D3D1BA2D /* SpectaUtility.m in Sources */,
-				B038AD02D30EC17B9D23EB9D1487382C /* SPTCallSite.m in Sources */,
-				A78EC25004EE56F06223E13322CB2FA6 /* SPTCompiledExample.m in Sources */,
-				B9BD17A05F5CCA4B178E0E0DC065D6D5 /* SPTExample.m in Sources */,
-				118288E4B5564DBB3FCFD7D568BA34F9 /* SPTExampleGroup.m in Sources */,
-				8A87FB401B93066DD8C85AAB9CDBC11A /* SPTSharedExampleGroups.m in Sources */,
-				4A8FD952823FAC67C04EB7F52F6B3881 /* SPTSpec.m in Sources */,
-				57FA908BAA9E8857F78965B0CF320A22 /* SPTTestSuite.m in Sources */,
-				187F46423F8CC699E4EC5B013DADF043 /* XCTestCase+Specta.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8559F319F13540B66A857B6CFF67836E /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1FA53FB61D99D37B11CF3D7568F1FAA2 /* Pods-Segment-GoogleAnalytics_Example-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EF6D2DF45C8F0BE6ED157435C762B99A /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				486B65BB914388EA36C58304C6039F1F /* Analytics-dummy.m in Sources */,
-				0EBFCC5B0D8267DB953A68498EC7D758 /* SEGAliasPayload.m in Sources */,
-				8F8B382D1231AE6FCA478E3C79F036AD /* SEGAnalytics.m in Sources */,
-				7F99F346CEC7597BC4AD63F1E966D594 /* SEGAnalyticsRequest.m in Sources */,
-				B5F7A213B1C490590EFAB25DF6AFD48A /* SEGAnalyticsUtils.m in Sources */,
-				68E10C74572004B18490C31A0757E3B2 /* SEGBluetooth.m in Sources */,
-				66ED669D42B1035789CE51D6A5C86EB0 /* SEGGroupPayload.m in Sources */,
-				B09EF0FD07655A036EF25A09252EC9A9 /* SEGIdentifyPayload.m in Sources */,
-				B309BC0D714443A4A815F45FECB8AAB1 /* SEGLocation.m in Sources */,
-				EB27473B3153D1A32E331F8C3BC98E15 /* SEGPayload.m in Sources */,
-				A2A91F93C68DAE8C18FE53F6EA15D54D /* SEGReachability.m in Sources */,
-				10640AF349457B2280632CECCCA5FE7C /* SEGScreenPayload.m in Sources */,
-				3CF85CEBEA5339235C29E19B55D944ED /* SEGSegmentIntegration.m in Sources */,
-				8B1B60B7C24DCFAC0081FE5432C10942 /* SEGSegmentIntegrationFactory.m in Sources */,
-				02FA0FA148C2B4F13646BCD671C1DC0D /* SEGTrackPayload.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F8A3174F1370ED9A57F94C3ED212C70E /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				23C308732876898CC780DC4FD8A09F4C /* SEGGoogleAnalyticsIntegration.m in Sources */,
-				5898D23317AA2AC18E0FD933409C5E9F /* SEGGoogleAnalyticsIntegrationFactory.m in Sources */,
-				5DD6A636555E18CB2AEB2903355B1551 /* Segment-GoogleAnalytics-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		1D79E234B869C1FA242E45E7DCB4A100 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Specta;
-			target = 9A7702F7DB899DC0B318CF2119620155 /* Specta */;
-			targetProxy = 0082E7EAE614FC3473892AEBEDFFBB1B /* PBXContainerItemProxy */;
-		};
-		5379BFDE6004D230B23CB016EB03E197 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Analytics;
-			target = E703EF8141AB3D56D46182B4EA5FB571 /* Analytics */;
-			targetProxy = F9015232CB5F2A63DB560C88DCF86512 /* PBXContainerItemProxy */;
-		};
-		6DDC1EFBB7D02CDCC05FCF39C83AE2C9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Expecta;
-			target = 2F501FE84845EAD97B9087DAFCBBEE0E /* Expecta */;
-			targetProxy = A4644EDA4C4D6F333FB54B441CB67E93 /* PBXContainerItemProxy */;
-		};
-		6F219A4367F11919243ABEDBE901877C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Segment-GoogleAnalytics";
-			target = 859E063BB03DDB2C5D9A99DB427478EA /* Segment-GoogleAnalytics */;
-			targetProxy = BCF9B107370736590CF156865DDE2E24 /* PBXContainerItemProxy */;
-		};
-		77BE6CC9369C45EFBC1FD1A322BFD975 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Analytics;
-			target = E703EF8141AB3D56D46182B4EA5FB571 /* Analytics */;
-			targetProxy = 2CDEF66D198FA82D47E8C5065823C834 /* PBXContainerItemProxy */;
-		};
-		ABF9EC2DB5BBC2E9086DA001DAFE23F0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Segment-GoogleAnalytics";
-			target = 859E063BB03DDB2C5D9A99DB427478EA /* Segment-GoogleAnalytics */;
-			targetProxy = 30F56C861EE89640CE6C9F59CA056520 /* PBXContainerItemProxy */;
-		};
-		EFA2F8627C19B0786403860E75168CF4 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Analytics;
-			target = E703EF8141AB3D56D46182B4EA5FB571 /* Analytics */;
-			targetProxy = 548C4C3F0491EA8ADB64767E149A8DF5 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
-/* Begin XCBuildConfiguration section */
-		18D2D1F8D8D2C1AB3ACA586DE2F5C814 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 558A49FF40959AE7147F14C765269D33 /* Analytics.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Analytics/Analytics-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		1BC29259D6F9F1A79B534F2B8B4D8363 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1DB0E1341AF1923C7D66E6695062860B /* Expecta.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Expecta/Expecta-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		1DA98680564D9B03C59D534987FC7792 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E200A1F712D8C70CEE0ABE0ACDE4D904 /* Pods-Segment-GoogleAnalytics_Tests.debug.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACH_O_TYPE = staticlib;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		505C6B9848A4559223A718CAA55039C1 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = D0B9C9663686AD4EC06FA9062E80A8F0 /* Pods-Segment-GoogleAnalytics_Example.release.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACH_O_TYPE = staticlib;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		6E073A0D16A8DFAEE80519C2A1D9553C /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1DB0E1341AF1923C7D66E6695062860B /* Expecta.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Expecta/Expecta-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		7A3C46FD9F45AE288519FB8A642FB17D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 003E1FF25B624503C0B7DE8E09FFCD2E /* Specta.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		9880405C14D519BEE71EC813F6A7BBF9 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9E7AED6529044F5A3F1798885FA0EB66 /* Segment-GoogleAnalytics.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Segment-GoogleAnalytics/Segment-GoogleAnalytics-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		A70CDAD61F90AC503C7D04CC22DA2923 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				ONLY_ACTIVE_ARCH = YES;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-			};
-			name = Debug;
-		};
-		C08BC501533D0ED2041A5BEDAC7BF10A /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 003E1FF25B624503C0B7DE8E09FFCD2E /* Specta.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Specta/Specta-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		C08D1B602D6625CEA47ACD780698D832 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = CAAE62E8DB86653476BDEDF0B6664DBD /* Pods-Segment-GoogleAnalytics_Tests.release.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACH_O_TYPE = staticlib;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		CBA9906B41948B0D8CAEE6AE031F3982 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C6ABA54126ECDD4523DA27371E0E9474 /* Pods-Segment-GoogleAnalytics_Example.debug.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MACH_O_TYPE = staticlib;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		E3D9551407884464577E58647CC2CDDE /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 558A49FF40959AE7147F14C765269D33 /* Analytics.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Analytics/Analytics-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		F30A41276DE3EE0553B4749F788F4B8A /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9E7AED6529044F5A3F1798885FA0EB66 /* Segment-GoogleAnalytics.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Segment-GoogleAnalytics/Segment-GoogleAnalytics-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRIVATE_HEADERS_FOLDER_PATH = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		FB45FFD90572718D82AB9092B750F0CA /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				A70CDAD61F90AC503C7D04CC22DA2923 /* Debug */,
-				FB45FFD90572718D82AB9092B750F0CA /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		3B24DD01561BA6B1F8D2B8C3F93630D7 /* Build configuration list for PBXNativeTarget "Pods-Segment-GoogleAnalytics_Example" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				CBA9906B41948B0D8CAEE6AE031F3982 /* Debug */,
-				505C6B9848A4559223A718CAA55039C1 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		57205495CF13B4EE93B13B7B0E3A1BD2 /* Build configuration list for PBXNativeTarget "Expecta" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				1BC29259D6F9F1A79B534F2B8B4D8363 /* Debug */,
-				6E073A0D16A8DFAEE80519C2A1D9553C /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		5FA20BA7A3A1E3F8092D2C94AFED6D76 /* Build configuration list for PBXNativeTarget "Pods-Segment-GoogleAnalytics_Tests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				1DA98680564D9B03C59D534987FC7792 /* Debug */,
-				C08D1B602D6625CEA47ACD780698D832 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		B1ABFB242198C5E38A6728EA931D52C8 /* Build configuration list for PBXNativeTarget "Segment-GoogleAnalytics" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				F30A41276DE3EE0553B4749F788F4B8A /* Debug */,
-				9880405C14D519BEE71EC813F6A7BBF9 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		D28FB9DCE5CE0170C17A7A54A9F819B3 /* Build configuration list for PBXNativeTarget "Specta" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				7A3C46FD9F45AE288519FB8A642FB17D /* Debug */,
-				C08BC501533D0ED2041A5BEDAC7BF10A /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		D69A20A8681184C1F18D69A2BB644717 /* Build configuration list for PBXNativeTarget "Analytics" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				E3D9551407884464577E58647CC2CDDE /* Debug */,
-				18D2D1F8D8D2C1AB3ACA586DE2F5C814 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>archiveVersion</key>
+	<string>1</string>
+	<key>classes</key>
+	<dict/>
+	<key>objectVersion</key>
+	<string>46</string>
+	<key>objects</key>
+	<dict>
+		<key>003E1FF25B624503C0B7DE8E09FFCD2E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Specta.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0082E7EAE614FC3473892AEBEDFFBB1B</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>9A7702F7DB899DC0B318CF2119620155</string>
+			<key>remoteInfo</key>
+			<string>Specta</string>
+		</dict>
+		<key>00AA78757DDCD095BADCC948F96D9918</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Pods-Segment-GoogleAnalytics_Tests-acknowledgements.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>021C50274FF43A6F07E119D572C3ACB6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>22FAD7D819C780BD3941E8361C9DE50E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>0230190DDFC91DA732D8624EF3C54A9E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beLessThanOrEqualTo.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>02C7E3EC1E1DFDD7046BD26A67E92686</key>
+		<dict>
+			<key>fileRef</key>
+			<string>76FDA2EF06A82D029BE55F779402A351</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>02FA0FA148C2B4F13646BCD671C1DC0D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>D99400BFB9A624D8E051FED7A1BDF315</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>03F690173163BA691C98E1D242100544</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>04CCA4E932E4555FE104E08F5A1F899A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Segment-GoogleAnalytics-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0632D8C7A85E2AB40699726F5382E847</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beInTheRangeOf.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beInTheRangeOf.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>067AB382C6EAF94F9525C2D3E798EA89</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-Segment-GoogleAnalytics_Tests-frameworks.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>07282695806D1DFBF187BFA004D80641</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DE73CB6561F92F5CB79F28F7A4303749</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>081F2104425CDCB0915354E2FBD7E24E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>E128AD4B837926B3A5A036D8E8DFECAD</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>08CD059C7FF78A67CA091A2E3008FDDF</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1638149FA560B7ED8704012F6E32B010</string>
+				<string>AA87D29C4C4D9CB70A5BB9010C93E406</string>
+				<string>CFAE41FD7F6F5C7D8E508C03208FFF59</string>
+				<string>91A2E492978527A73B3C4C3DD6B91C97</string>
+				<string>2837272F75DD845EF2A91B94FA9E38AA</string>
+				<string>CA511D8C5CCB276C4F4E948BD4A5939F</string>
+				<string>8C65EAD9F4779A546336645EC8E51355</string>
+				<string>11DDFBEEBD749A88975C8606A445C015</string>
+				<string>9317CA06C334C88F084CD88BF04618ED</string>
+				<string>4C1CE6534A62FA634E7867F189D282C2</string>
+				<string>97F182F971933BFEF29A646F7D22423E</string>
+				<string>52C7898921A306F30450C3679C050D2A</string>
+				<string>8857DA884D845E55149E2D0721FE2C41</string>
+				<string>1701C01002B6CA774E41013BCDCF6F72</string>
+				<string>C6B2685864B008D5854B7554B05FE815</string>
+				<string>2E0733A0038EE5736FF18B5A63792DA6</string>
+				<string>D1CB69C27633FCC3576F1778EFC09B7D</string>
+				<string>2C9CEECF04FC9560D547C3380931D78B</string>
+				<string>0D32FAD33571B227BE06BBB6E80444A8</string>
+				<string>FCF10D4D8159FFF95CFCDB62577AA8E4</string>
+				<string>6BD6385C8632CDBB33C3F694D32D44AC</string>
+				<string>81B495005EBD1E18D49D930C9F0DE1A4</string>
+				<string>231B198CBFD8DDBEF36D16F274FC83AE</string>
+				<string>5A5D0FD313A4B5E5A78C8A34A9B71607</string>
+				<string>7ED4DAD1A4FB242A6CE917329C32BDCB</string>
+				<string>7669417A2998C97CD154ABD987C5334E</string>
+				<string>3ABC5E4B4982D08ED7380A4C08E3418C</string>
+				<string>A35484475812F6496D912E772717EE78</string>
+				<string>3AD7BB555A10EBB24F11166027FCCB24</string>
+				<string>D99400BFB9A624D8E051FED7A1BDF315</string>
+				<string>F711FE6DE60FD2ED5D589F9C3262A6F3</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Analytics</string>
+			<key>path</key>
+			<string>Analytics</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0B89D65F93B8B964E748359C59731131</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Expecta-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0C6B012983F9FEF8CC65C1318F5F090C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>E351727CD07BB90B2A3CAE2C2433F6C5</string>
+				<string>279AA6492631DEFA8C439A9C088EEB8A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>iOS</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0D32FAD33571B227BE06BBB6E80444A8</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGPayload.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Integrations/SEGPayload.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0D61BFA15E780468CFF692FA8FFE5AFE</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPExpect.m</string>
+			<key>path</key>
+			<string>Expecta/EXPExpect.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0D99CDFBEB811EE97A2EE7BD42C8C872</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>GAIDictionaryBuilder.h</string>
+			<key>path</key>
+			<string>Headers/Public/GAIDictionaryBuilder.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>0DB6AFFBA2CB5525D9780F1DE6FAB593</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>6FF568E538D78F99F2EA1ED159B99766</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>0EBFCC5B0D8267DB953A68498EC7D758</key>
+		<dict>
+			<key>fileRef</key>
+			<string>AA87D29C4C4D9CB70A5BB9010C93E406</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>104AFE24D01F1C4495926B40B53C5945</key>
+		<dict>
+			<key>fileRef</key>
+			<string>0D61BFA15E780468CFF692FA8FFE5AFE</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>10640AF349457B2280632CECCCA5FE7C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>5A5D0FD313A4B5E5A78C8A34A9B71607</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>1090ADEE4E406645BC0603EF794F19AE</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>SEGGoogleAnalyticsIntegration.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>118288E4B5564DBB3FCFD7D568BA34F9</key>
+		<dict>
+			<key>fileRef</key>
+			<string>6807539CEC31F5EB61DC3B93ADD174C7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>11CF0C44A36897A963C15B74C2AEC415</key>
+		<dict>
+			<key>fileRef</key>
+			<string>90652227DA6C2B4C6C8E843F2F8BAC21</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>11DDFBEEBD749A88975C8606A445C015</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SEGAnalyticsUtils.m</string>
+			<key>path</key>
+			<string>Pod/Classes/Internal/SEGAnalyticsUtils.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>14327F0AB7B3F21ADB2B69A7DCA9CAF8</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>08CD059C7FF78A67CA091A2E3008FDDF</string>
+				<string>D7A891CE610ABA3D2BD4D00D054B959D</string>
+				<string>39E8D2657CF189783B72B6EFFA51ABAF</string>
+				<string>3D93154BBE7C924F2D97D53D2E80C80E</string>
+				<string>5A9F6CCBF5079AF61D9D0249A7C2B9C0</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>143C0831AA95D723669324010D835391</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>CF95446EA555B49150EA7270096D78B2</string>
+				<string>487899F028C39C1A518547A1AB2F625A</string>
+				<string>FDF72740DBC37AFACFED73ED42282383</string>
+				<string>11CF0C44A36897A963C15B74C2AEC415</string>
+				<string>4383E0DB1B07B9EB3155EF5D5F27C7BA</string>
+				<string>104AFE24D01F1C4495926B40B53C5945</string>
+				<string>779CFE8771E1EF63F1313ABEBCECAA4A</string>
+				<string>49EFE75BAF060A33327F3CE8C18436F2</string>
+				<string>5F6D96E64F890BDC4A75B73C3D50A0DD</string>
+				<string>F1F4E65611F5567A86AF797EAC3E225B</string>
+				<string>A7141BC83638F4B38D4D312BAE3BDAC4</string>
+				<string>CB08C9C83ABDBE55762A423ED48491EF</string>
+				<string>AD6791D14732A3C17164F61CC72FFB0D</string>
+				<string>A65C491577A425AF82C53F4A40A0A24B</string>
+				<string>2F9D3747596E4E074C3B776949091047</string>
+				<string>7436C602BB1CA7C91560C28DE749357B</string>
+				<string>63D0CD4F0FB5A6103E1DDB46E876CBB6</string>
+				<string>C6671739E8C5904113586F8BEBBC9780</string>
+				<string>43A1104CA0C628C2F693902EADA32B8C</string>
+				<string>E06376455C1D5E45B97ACDC5438FC15B</string>
+				<string>BD30B724A71CF5D6E93805B7615EC79C</string>
+				<string>6D37BEAA1FC469C3582CACB4E9766502</string>
+				<string>5E8F33E777456DA63CA2D902508A9058</string>
+				<string>C2BFF99EB859FD7056CF72C4850693D1</string>
+				<string>46F312CBB94BAE62B58D3D7AE28E8DBD</string>
+				<string>B33234F432A72D5E8B65694AE937B78F</string>
+				<string>8059E5674B08670B0A002D564FFABF44</string>
+				<string>562BE99A6F630E709218EB9B3CF36E90</string>
+				<string>2239B5E63C5D2C1323D66F489F075C42</string>
+				<string>69EBB956302554EA37775F4D806BC4DD</string>
+				<string>7FEE0E8D094D7BCCAC7129473EE05ADC</string>
+				<string>A26F992E8831118311F3DB7CB830595A</string>
+				<string>E2EBD18BA89D3FF648947DF31FA12D44</string>
+				<string>40F505E69B8595361C2A7528DDA222B6</string>
+				<string>872948DAF79618AD725E0BF364E5DDD4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>147BB6B93BF01AB27D7C213F8FFC0F0A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>GAITrackedViewController.h</string>
+			<key>path</key>
+			<string>Headers/Public/GAITrackedViewController.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>14C609D8F203FD45194E93997EFF744E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>6A2147C8C8E0A818D9BC42DC2F23709B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>1638149FA560B7ED8704012F6E32B010</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGAliasPayload.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Integrations/SEGAliasPayload.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>16EC47C0D8BADA487C115973D26718A7</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>50479B6EF1A2C74265F5AB553CFC56F2</string>
+				<string>E8D41CF69BC7D498C16F3887A021F4BA</string>
+				<string>9F4084E6D71859700239E620D3D1BA2D</string>
+				<string>B038AD02D30EC17B9D23EB9D1487382C</string>
+				<string>A78EC25004EE56F06223E13322CB2FA6</string>
+				<string>B9BD17A05F5CCA4B178E0E0DC065D6D5</string>
+				<string>118288E4B5564DBB3FCFD7D568BA34F9</string>
+				<string>8A87FB401B93066DD8C85AAB9CDBC11A</string>
+				<string>4A8FD952823FAC67C04EB7F52F6B3881</string>
+				<string>57FA908BAA9E8857F78965B0CF320A22</string>
+				<string>187F46423F8CC699E4EC5B013DADF043</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>1701C01002B6CA774E41013BCDCF6F72</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SEGIdentifyPayload.m</string>
+			<key>path</key>
+			<string>Pod/Classes/Integrations/SEGIdentifyPayload.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1752D706BA25FF27E5712204C17F8745</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>3B24DD01561BA6B1F8D2B8C3F93630D7</string>
+			<key>buildPhases</key>
+			<array>
+				<string>8559F319F13540B66A857B6CFF67836E</string>
+				<string>915945EFDF699B928B3BE5F473CDA320</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>5379BFDE6004D230B23CB016EB03E197</string>
+				<string>6F219A4367F11919243ABEDBE901877C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Pods-Segment-GoogleAnalytics_Example</string>
+			<key>productName</key>
+			<string>Pods-Segment-GoogleAnalytics_Example</string>
+			<key>productReference</key>
+			<string>D58B97E6820E236C055063572F1E32A2</string>
+			<key>productType</key>
+			<string>com.apple.product-type.library.static</string>
+		</dict>
+		<key>17A3F1607267A4CD0D8B76C017299F78</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beGreaterThan.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beGreaterThan.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>187F46423F8CC699E4EC5B013DADF043</key>
+		<dict>
+			<key>fileRef</key>
+			<string>AAAFAFFB150A80628C686DDD8D642B9D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>18D2D1F8D8D2C1AB3ACA586DE2F5C814</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>558A49FF40959AE7147F14C765269D33</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Analytics/Analytics-prefix.pch</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PRIVATE_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>191BD56D6E43E54A25DA0A5C308A2752</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>49496209C5711E0D5A4A51DCF8FB8DEC</string>
+				<string>C345B90819C4CE033B07926CFEEF9644</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>195673BC1D4EBD3D604A447FFEF80200</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPDefines.h</string>
+			<key>path</key>
+			<string>Expecta/EXPDefines.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>199EF76AC47B3EE9FA80BE53835AB7B1</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>66081D3480D1FA028C4DE2344BF616D4</string>
+				<string>69363A59A4E2FF95D6A62AA88641A20A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>19BA3A4E9AB74D50BA74D05C5A3A497B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+postNotification.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+postNotification.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1A6546EF89124663B2E4A520D1C2CA20</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>A8ABFA4EFC8E5E19332345AE253640A0</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1BB5FCB799A3E132B5FAA78FAF5AD39C</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>libExpecta.a</string>
+			<key>path</key>
+			<string>libExpecta.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>1BC29259D6F9F1A79B534F2B8B4D8363</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>1DB0E1341AF1923C7D66E6695062860B</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Expecta/Expecta-prefix.pch</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PRIVATE_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>1D79E234B869C1FA242E45E7DCB4A100</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Specta</string>
+			<key>target</key>
+			<string>9A7702F7DB899DC0B318CF2119620155</string>
+			<key>targetProxy</key>
+			<string>0082E7EAE614FC3473892AEBEDFFBB1B</string>
+		</dict>
+		<key>1DA98680564D9B03C59D534987FC7792</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>E200A1F712D8C70CEE0ABE0ACDE4D904</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>1DB0E1341AF1923C7D66E6695062860B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Expecta.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1ECBFFA672D10773C52B801D99B88FBE</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SPTExcludeGlobalBeforeAfterEach.h</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTExcludeGlobalBeforeAfterEach.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>1FA53FB61D99D37B11CF3D7568F1FAA2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>98AF2EF29263F6E5F2917A01134D91A1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>203F34C34A866E23F7B4CF5C17CA8EA5</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SPTGlobalBeforeAfterEach.h</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTGlobalBeforeAfterEach.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>207058C172433AEE54F3D861929C009B</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>56CAFEE86D5B03E4EC14D45E00544678</string>
+				<string>C455239AD9C4D14DE61DD20A51A59635</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Segment-GoogleAnalytics</string>
+			<key>path</key>
+			<string>../..</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>20931BF25C1C314AD48793C2B3EFB1DD</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SPTCompiledExample.m</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTCompiledExample.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2239B5E63C5D2C1323D66F489F075C42</key>
+		<dict>
+			<key>fileRef</key>
+			<string>FF44A189D47E0B1CB7FA13DE72A685BB</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>22F3505207F93C01E28757C157D01EEB</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Expecta-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>22FAD7D819C780BD3941E8361C9DE50E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beginWith.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beginWith.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>231B198CBFD8DDBEF36D16F274FC83AE</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGScreenPayload.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Integrations/SEGScreenPayload.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>237FB063FB365119546C7B5006224F3B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>FAE4AA155A2514A44DCF02CDE86885CF</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>23C308732876898CC780DC4FD8A09F4C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1090ADEE4E406645BC0603EF794F19AE</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>2494E91B1F913E639B70B22D66D6B52F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beLessThan.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beLessThan.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>25B28C645D7048EE8533D648851B36DE</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>CBC8E95BD4789904887E8E44506F2E19</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>25BBDA674BE9447D354412C79BF4B16C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C6B2685864B008D5854B7554B05FE815</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>26EDC865188F93E75C783CD41E307006</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>855FF2069FE35409211B068CF74D1BC9</string>
+				<string>9936109944D13524536A31583D20FC5C</string>
+				<string>98AF2EF29263F6E5F2917A01134D91A1</string>
+				<string>A8BCFD4057C083FF8B2B91CAA2A517AD</string>
+				<string>B9ADDA29B749820D119249DA1929589E</string>
+				<string>C6ABA54126ECDD4523DA27371E0E9474</string>
+				<string>D0B9C9663686AD4EC06FA9062E80A8F0</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods-Segment-GoogleAnalytics_Example</string>
+			<key>path</key>
+			<string>Target Support Files/Pods-Segment-GoogleAnalytics_Example</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>26FDD94D57A937677D2A42E53E7DBD7A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>3ABC5E4B4982D08ED7380A4C08E3418C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>2743254252516E0A88873C5402573C5B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPFloatTuple.m</string>
+			<key>path</key>
+			<string>Expecta/EXPFloatTuple.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>277DE8AADE10662CAE402205802458BA</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+equal.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+equal.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>279AA6492631DEFA8C439A9C088EEB8A</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>XCTest.framework</string>
+			<key>path</key>
+			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/XCTest.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>27B1B54BB2BA7B78455DCEB2FEF70BC6</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>XCTestCase+Specta.h</string>
+			<key>path</key>
+			<string>Specta/Specta/XCTestCase+Specta.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2837272F75DD845EF2A91B94FA9E38AA</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGAnalyticsRequest.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Internal/SEGAnalyticsRequest.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2945FAA75C956DD6A541EB51E42E6899</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2D88ACEFC22E13FCF6F27A591CCC1D53</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>2A17721E4A81DB608CA6D4FB6F0ADAFB</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EDB92F0DECBE15130358426D5213D6C8</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>2C9B4D847287245CC715A02DD0F307E1</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beLessThan.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beLessThan.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2C9CEECF04FC9560D547C3380931D78B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SEGLocation.m</string>
+			<key>path</key>
+			<string>Pod/Classes/Internal/SEGLocation.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2CDDCDCA361D583C58B28EF022F8387E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>27B1B54BB2BA7B78455DCEB2FEF70BC6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>2CDEF66D198FA82D47E8C5065823C834</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>E703EF8141AB3D56D46182B4EA5FB571</string>
+			<key>remoteInfo</key>
+			<string>Analytics</string>
+		</dict>
+		<key>2D881B10160E6AA5B265F69CA2F53159</key>
+		<dict>
+			<key>fileRef</key>
+			<string>7C1E9D81E228F9B07251DEEB275F4744</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>2D88ACEFC22E13FCF6F27A591CCC1D53</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+conformTo.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+conformTo.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2D8E8EC45A3A1A1D94AE762CB5028504</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>A70CDAD61F90AC503C7D04CC22DA2923</string>
+				<string>FB45FFD90572718D82AB9092B750F0CA</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>2E0733A0038EE5736FF18B5A63792DA6</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGIntegrationFactory.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Integrations/SEGIntegrationFactory.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2E91479DE86808F686A59942FC879D8E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beIdenticalTo.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beIdenticalTo.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>2F501FE84845EAD97B9087DAFCBBEE0E</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>57205495CF13B4EE93B13B7B0E3A1BD2</string>
+			<key>buildPhases</key>
+			<array>
+				<string>143C0831AA95D723669324010D835391</string>
+				<string>199EF76AC47B3EE9FA80BE53835AB7B1</string>
+				<string>C6AD7852D34E8A80DFF3B8376BDE812F</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Expecta</string>
+			<key>productName</key>
+			<string>Expecta</string>
+			<key>productReference</key>
+			<string>1BB5FCB799A3E132B5FAA78FAF5AD39C</string>
+			<key>productType</key>
+			<string>com.apple.product-type.library.static</string>
+		</dict>
+		<key>2F824EA28F819F2E4A9E6D31E14D0603</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CFAE41FD7F6F5C7D8E508C03208FFF59</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>2F9D3747596E4E074C3B776949091047</key>
+		<dict>
+			<key>fileRef</key>
+			<string>90552A900C20BA732E285A6C8CDB4660</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>2FC2FBF5CAFA206F9C92EC6A22AC0B84</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Analytics-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>305B6661988E84D5D0C3B158B277BEAC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatcherHelpers.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatcherHelpers.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>30F56C861EE89640CE6C9F59CA056520</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>859E063BB03DDB2C5D9A99DB427478EA</string>
+			<key>remoteInfo</key>
+			<string>Segment-GoogleAnalytics</string>
+		</dict>
+		<key>339A0C1BFF72397A705959E03877DDDB</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8DC6005FC38AC1939F82F6C1FB9A2E36</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>341D7536159B52F41598F730CC45D548</key>
+		<dict>
+			<key>fileRef</key>
+			<string>56BBCF71F950D6191CD6B1B91A85FA82</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>3756FB16CD0261AA42611CD5D01B88C7</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SPTSharedExampleGroups.h</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTSharedExampleGroups.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>39E8D2657CF189783B72B6EFFA51ABAF</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>CCDE6708F49E9734E245E14F26FEC611</string>
+				<string>0D99CDFBEB811EE97A2EE7BD42C8C872</string>
+				<string>E9E5EFF4A45283579A977D61C2FEE50C</string>
+				<string>8DDB38718F95D76871BD12B66C61FB29</string>
+				<string>4A023A20387157632011915438018BA0</string>
+				<string>9F56505149E55909F48A9E238EC226EC</string>
+				<string>F242671BEF9F47004BD4AEA6994ACB6B</string>
+				<string>CF6E7D5EB1BE0988C685F173F5871BC8</string>
+				<string>147BB6B93BF01AB27D7C213F8FFC0F0A</string>
+				<string>803929AB0EC5B999F71365235E2FC569</string>
+				<string>9F4BA3995289C6236CF8558CE17CD670</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>GoogleAnalytics</string>
+			<key>path</key>
+			<string>GoogleAnalytics</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>39E9492F7292B43EF5DE6007F51DA0EC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+match.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+match.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3A013F13122CDB8EE962F8CB7C6FCC8E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B4B89A8180E266D6FD109356EBE762DA</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>3ABC5E4B4982D08ED7380A4C08E3418C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGSegmentIntegrationFactory.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Internal/SEGSegmentIntegrationFactory.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3AD7BB555A10EBB24F11166027FCCB24</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGTrackPayload.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Integrations/SEGTrackPayload.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3B24DD01561BA6B1F8D2B8C3F93630D7</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>CBA9906B41948B0D8CAEE6AE031F3982</string>
+				<string>505C6B9848A4559223A718CAA55039C1</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>3CF85CEBEA5339235C29E19B55D944ED</key>
+		<dict>
+			<key>fileRef</key>
+			<string>7669417A2998C97CD154ABD987C5334E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>3D508F6B13170EC5036ECEEECB475BA4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>3756FB16CD0261AA42611CD5D01B88C7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>3D93154BBE7C924F2D97D53D2E80C80E</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1A6546EF89124663B2E4A520D1C2CA20</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>GoogleIDFASupport</string>
+			<key>path</key>
+			<string>GoogleIDFASupport</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3E4490F950B5EC6EAC20E6BD37E9C14E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beInTheRangeOf.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beInTheRangeOf.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>3E463E2B6917D9AA08A03BA8A8E74A18</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C9E85A65EFBEA8CB9F441C68B3E492C1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>4075E3A20D226B9478030380B33E3EEE</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beNil.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beNil.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>40F505E69B8595361C2A7528DDA222B6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>66A04F37AA8446E5F76E605B220607FA</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>41D47B37FDEA46945606C39C44042D8C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>D1CB69C27633FCC3576F1778EFC09B7D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>41D48B8BD24D516FA56686BDD2A113C2</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SPTSpec.h</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTSpec.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>41DDF8C028B6E5026AD5CC5BAD2AAA3B</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>libSegment-GoogleAnalytics.a</string>
+			<key>path</key>
+			<string>libSegment-GoogleAnalytics.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>4231743B6C143BDB4A5FBB032E6D3799</key>
+		<dict>
+			<key>fileRef</key>
+			<string>869F6CDA9DFD53454C106CBA668F580E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>430CE433DB59FE090A8CC6AFCFA43337</key>
+		<dict>
+			<key>fileRef</key>
+			<string>90A6E1569ECE25A96D932D7CB0456A00</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>433CD3331B6C3787F473C941B61FC68F</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>0C6B012983F9FEF8CC65C1318F5F090C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>43659A5034D2F6C8510DDC52EFD7B7CA</key>
+		<dict>
+			<key>fileRef</key>
+			<string>56F3B4B2BD22271258A1CB037C17CF99</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>4383E0DB1B07B9EB3155EF5D5F27C7BA</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C258607F1A902F6E3358877275B1C45D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>43A1104CA0C628C2F693902EADA32B8C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>0230190DDFC91DA732D8624EF3C54A9E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>44727FC65C18BECDF363D9F7AE53FC15</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>C0243D80A39E6D84988415B3206EBCF0</string>
+				<string>1BB5FCB799A3E132B5FAA78FAF5AD39C</string>
+				<string>D58B97E6820E236C055063572F1E32A2</string>
+				<string>986E88CA93CED9C4B4963349457B2AA8</string>
+				<string>41DDF8C028B6E5026AD5CC5BAD2AAA3B</string>
+				<string>8811C2CFB32EDC145242E31D1D6000C3</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Products</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4511AE2A42381FF1A3B3C12144FC0C0E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SpectaDSL.h</string>
+			<key>path</key>
+			<string>Specta/Specta/SpectaDSL.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>463DA29EAC33AE0F642267ADB9876178</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPBlockDefinedMatcher.h</string>
+			<key>path</key>
+			<string>Expecta/EXPBlockDefinedMatcher.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>46F312CBB94BAE62B58D3D7AE28E8DBD</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A76D476E5FC248FFF04B019CFE53E21A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>475BBFA6E99B39CB8429C0B71972E445</key>
+		<dict>
+			<key>fileRef</key>
+			<string>7146A0979739F3A21FF50C0953C8D2A0</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>486B65BB914388EA36C58304C6039F1F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CBFEA0C6D4EBA470E98B90635BAB38B2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>487899F028C39C1A518547A1AB2F625A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>F3165B876D08CD102EA891025959EB19</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>49496209C5711E0D5A4A51DCF8FB8DEC</key>
+		<dict>
+			<key>fileRef</key>
+			<string>F7DE9BBD243370BF8EFFF25D7E85CD4C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>49EFE75BAF060A33327F3CE8C18436F2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>E3554BD7A107F9879E5EB62B4F8C2A35</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>4A023A20387157632011915438018BA0</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>GAIEcommerceProductAction.h</string>
+			<key>path</key>
+			<string>Headers/Public/GAIEcommerceProductAction.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4A8FD952823FAC67C04EB7F52F6B3881</key>
+		<dict>
+			<key>fileRef</key>
+			<string>5400AA6F166FE7EE163E4966C6466D21</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>4B0EA949E5076B09ED0B24C22053F953</key>
+		<dict>
+			<key>fileRef</key>
+			<string>203F34C34A866E23F7B4CF5C17CA8EA5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>4C1CE6534A62FA634E7867F189D282C2</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SEGBluetooth.m</string>
+			<key>path</key>
+			<string>Pod/Classes/Internal/SEGBluetooth.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4C84E03C3810D3CB1B6F36216A398A2E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beCloseTo.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beCloseTo.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4D12FAE56109712094DA78D38B05DA2C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beFalsy.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beFalsy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4DC954F6F5AB56AE2D793E9ACA45624D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beNil.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beNil.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4F399E73BB1F0DA1C2966C111EA9C7EE</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>path</key>
+			<string>Pods-Segment-GoogleAnalytics_Tests-acknowledgements.markdown</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>4F7810CA7C3360CA27786A4189D1F13A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+respondTo.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+respondTo.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>503BF36CDAFC3DE4E6862924EFF5DF1D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>E351727CD07BB90B2A3CAE2C2433F6C5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>50479B6EF1A2C74265F5AB553CFC56F2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EEA295B5F005DA5BE3281CE44E4D995D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>505C6B9848A4559223A718CAA55039C1</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>D0B9C9663686AD4EC06FA9062E80A8F0</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>518A7131AD41523DC00501D702A1EF88</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beGreaterThanOrEqualTo.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>51F974C6782C68F90D278FCEA769A59E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>SEGGoogleAnalyticsIntegrationFactory.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>52C7898921A306F30450C3679C050D2A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SEGGroupPayload.m</string>
+			<key>path</key>
+			<string>Pod/Classes/Integrations/SEGGroupPayload.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5379BFDE6004D230B23CB016EB03E197</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Analytics</string>
+			<key>target</key>
+			<string>E703EF8141AB3D56D46182B4EA5FB571</string>
+			<key>targetProxy</key>
+			<string>F9015232CB5F2A63DB560C88DCF86512</string>
+		</dict>
+		<key>539C2C0907CA46CC4DE78E19B1AFFA8E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9317CA06C334C88F084CD88BF04618ED</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>5400AA6F166FE7EE163E4966C6466D21</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SPTSpec.m</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTSpec.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>548C4C3F0491EA8ADB64767E149A8DF5</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>E703EF8141AB3D56D46182B4EA5FB571</string>
+			<key>remoteInfo</key>
+			<string>Analytics</string>
+		</dict>
+		<key>55345A779F22C7147507AC695CE3B85B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>XCTest+Private.h</string>
+			<key>path</key>
+			<string>Specta/Specta/XCTest+Private.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>558A49FF40959AE7147F14C765269D33</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Analytics.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>562BE99A6F630E709218EB9B3CF36E90</key>
+		<dict>
+			<key>fileRef</key>
+			<string>79C247F75A75B96048791BEBE10B0B03</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>568C2BF10FCA51F625ECC214C3A9D520</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SpectaUtility.m</string>
+			<key>path</key>
+			<string>Specta/Specta/SpectaUtility.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>56BBCF71F950D6191CD6B1B91A85FA82</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPFloatTuple.h</string>
+			<key>path</key>
+			<string>Expecta/EXPFloatTuple.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>56CAFEE86D5B03E4EC14D45E00544678</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>98DF4A3BC1F64C0C071727A6031AF527</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pod</string>
+			<key>path</key>
+			<string>Pod</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>56F3B4B2BD22271258A1CB037C17CF99</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SPTExampleGroup.h</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTExampleGroup.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>57205495CF13B4EE93B13B7B0E3A1BD2</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>1BC29259D6F9F1A79B534F2B8B4D8363</string>
+				<string>6E073A0D16A8DFAEE80519C2A1D9553C</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>578995B5D7A1B89485396FD3F985F3C1</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>Specta-prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>57FA908BAA9E8857F78965B0CF320A22</key>
+		<dict>
+			<key>fileRef</key>
+			<string>66266AC3D90E76C93DFDBE52120305BE</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>5898D23317AA2AC18E0FD933409C5E9F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>99AF585D638505D532A2B91329682F8E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>58EB5E47E144CBC4F4FE00C8F2B1AB95</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>5FA20BA7A3A1E3F8092D2C94AFED6D76</string>
+			<key>buildPhases</key>
+			<array>
+				<string>0DB6AFFBA2CB5525D9780F1DE6FAB593</string>
+				<string>EFC467B0EE8E1392E489559EAD8220D2</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>77BE6CC9369C45EFBC1FD1A322BFD975</string>
+				<string>6DDC1EFBB7D02CDCC05FCF39C83AE2C9</string>
+				<string>ABF9EC2DB5BBC2E9086DA001DAFE23F0</string>
+				<string>1D79E234B869C1FA242E45E7DCB4A100</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Pods-Segment-GoogleAnalytics_Tests</string>
+			<key>productName</key>
+			<string>Pods-Segment-GoogleAnalytics_Tests</string>
+			<key>productReference</key>
+			<string>986E88CA93CED9C4B4963349457B2AA8</string>
+			<key>productType</key>
+			<string>com.apple.product-type.library.static</string>
+		</dict>
+		<key>5A2F6E1360B9C61485920F5D5473A974</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beIdenticalTo.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beIdenticalTo.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5A5D0FD313A4B5E5A78C8A34A9B71607</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SEGScreenPayload.m</string>
+			<key>path</key>
+			<string>Pod/Classes/Integrations/SEGScreenPayload.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5A9F6CCBF5079AF61D9D0249A7C2B9C0</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>7C1E9D81E228F9B07251DEEB275F4744</string>
+				<string>4511AE2A42381FF1A3B3C12144FC0C0E</string>
+				<string>C1C171166E9393E8C112CDC72CDEBF13</string>
+				<string>7146A0979739F3A21FF50C0953C8D2A0</string>
+				<string>7FD3BC43A6C31A97BF932D9F18311E76</string>
+				<string>568C2BF10FCA51F625ECC214C3A9D520</string>
+				<string>789F69996FFDE3AECA5AF9C317B256B6</string>
+				<string>76948DA1B8E447BB5BAEBFBBF91D38EF</string>
+				<string>67D33B9C02CA7DFBF73919E3CE31AD7A</string>
+				<string>20931BF25C1C314AD48793C2B3EFB1DD</string>
+				<string>D327A699D86B9304B2D3FEAB534333DC</string>
+				<string>9A3BD1002DD3D3877A0AD6DC83B9AFC7</string>
+				<string>56F3B4B2BD22271258A1CB037C17CF99</string>
+				<string>6807539CEC31F5EB61DC3B93ADD174C7</string>
+				<string>1ECBFFA672D10773C52B801D99B88FBE</string>
+				<string>203F34C34A866E23F7B4CF5C17CA8EA5</string>
+				<string>3756FB16CD0261AA42611CD5D01B88C7</string>
+				<string>F2848ECE86915EED9032636E866D125F</string>
+				<string>41D48B8BD24D516FA56686BDD2A113C2</string>
+				<string>5400AA6F166FE7EE163E4966C6466D21</string>
+				<string>B658C2B4FB8A46E92A154CFF1291537A</string>
+				<string>66266AC3D90E76C93DFDBE52120305BE</string>
+				<string>55345A779F22C7147507AC695CE3B85B</string>
+				<string>27B1B54BB2BA7B78455DCEB2FEF70BC6</string>
+				<string>AAAFAFFB150A80628C686DDD8D642B9D</string>
+				<string>D6E18A324EC0EBA79E68C000D042CCB0</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Specta</string>
+			<key>path</key>
+			<string>Specta</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5DD6A636555E18CB2AEB2903355B1551</key>
+		<dict>
+			<key>fileRef</key>
+			<string>D671DB178CE02AEA19CBF062C3596692</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>5E8F33E777456DA63CA2D902508A9058</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8AF5B07DCDCBE1BC22042D777A38B464</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>5F5D27B4777037698149BC2D9793405F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>NSValue+Expecta.m</string>
+			<key>path</key>
+			<string>Expecta/NSValue+Expecta.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>5F6D96E64F890BDC4A75B73C3D50A0DD</key>
+		<dict>
+			<key>fileRef</key>
+			<string>86F591E03C6A2C071821D67283CFF54D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>5FA20BA7A3A1E3F8092D2C94AFED6D76</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>1DA98680564D9B03C59D534987FC7792</string>
+				<string>C08D1B602D6625CEA47ACD780698D832</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>605CADFBD63A01EDAA5A251B60B2C6AA</key>
+		<dict>
+			<key>fileRef</key>
+			<string>B658C2B4FB8A46E92A154CFF1291537A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>60D3CCEB5B53542228790ABD8885AF42</key>
+		<dict>
+			<key>fileRef</key>
+			<string>BDA0B809F5CE67054059064E81CBAF5F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>61D10D4273167662735D83D780C56F89</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+endWith.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+endWith.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>63D0CD4F0FB5A6103E1DDB46E876CBB6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C90EFAB73AD4A25DD1A311ACFB030AE8</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>66081D3480D1FA028C4DE2344BF616D4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>E351727CD07BB90B2A3CAE2C2433F6C5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>661A7213AFBB8E769759DBE86DCAE8EB</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>Expecta.h</string>
+			<key>path</key>
+			<string>Expecta/Expecta.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>66266AC3D90E76C93DFDBE52120305BE</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SPTTestSuite.m</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTTestSuite.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6656F35498E5573ED9F890D8B828B828</key>
+		<dict>
+			<key>fileRef</key>
+			<string>67D33B9C02CA7DFBF73919E3CE31AD7A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>666C57509FA1B9FD91574E36B4521896</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Pods-Segment-GoogleAnalytics_Tests-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>66A04F37AA8446E5F76E605B220607FA</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPUnsupportedObject.m</string>
+			<key>path</key>
+			<string>Expecta/EXPUnsupportedObject.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>66ED669D42B1035789CE51D6A5C86EB0</key>
+		<dict>
+			<key>fileRef</key>
+			<string>52C7898921A306F30450C3679C050D2A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>67D33B9C02CA7DFBF73919E3CE31AD7A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SPTCompiledExample.h</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTCompiledExample.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6807539CEC31F5EB61DC3B93ADD174C7</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SPTExampleGroup.m</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTExampleGroup.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>68E10C74572004B18490C31A0757E3B2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>4C1CE6534A62FA634E7867F189D282C2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>6924E116731D7079958063A3EE0781ED</key>
+		<dict>
+			<key>fileRef</key>
+			<string>03F690173163BA691C98E1D242100544</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>69363A59A4E2FF95D6A62AA88641A20A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>279AA6492631DEFA8C439A9C088EEB8A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>69EBB956302554EA37775F4D806BC4DD</key>
+		<dict>
+			<key>fileRef</key>
+			<string>19BA3A4E9AB74D50BA74D05C5A3A497B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>6A1C939D28292C3A5B4011F361790762</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>ExpectaSupport.h</string>
+			<key>path</key>
+			<string>Expecta/ExpectaSupport.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6A2147C8C8E0A818D9BC42DC2F23709B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beSubclassOf.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beSubclassOf.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6A4E3ACA285A21392936C110E7EC91F0</key>
+		<dict>
+			<key>fileRef</key>
+			<string>195673BC1D4EBD3D604A447FFEF80200</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>6BD6385C8632CDBB33C3F694D32D44AC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGReachability.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Internal/SEGReachability.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6CBB0742821FD4D346404011AE148582</key>
+		<dict>
+			<key>fileRef</key>
+			<string>231B198CBFD8DDBEF36D16F274FC83AE</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>6D00BA5555F1E5B354F14BDC1A0274B9</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>1DB0E1341AF1923C7D66E6695062860B</string>
+				<string>22F3505207F93C01E28757C157D01EEB</string>
+				<string>0B89D65F93B8B964E748359C59731131</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/Expecta</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6D37BEAA1FC469C3582CACB4E9766502</key>
+		<dict>
+			<key>fileRef</key>
+			<string>ED4F564CFDAA4CBE9BBFBECE5695AA05</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>6DDC1EFBB7D02CDCC05FCF39C83AE2C9</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Expecta</string>
+			<key>target</key>
+			<string>2F501FE84845EAD97B9087DAFCBBEE0E</string>
+			<key>targetProxy</key>
+			<string>A4644EDA4C4D6F333FB54B441CB67E93</string>
+		</dict>
+		<key>6E073A0D16A8DFAEE80519C2A1D9553C</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>1DB0E1341AF1923C7D66E6695062860B</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Expecta/Expecta-prefix.pch</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PRIVATE_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>6EAF2E95795D983AC7CE49F822DA3827</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>207058C172433AEE54F3D861929C009B</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Development Pods</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>6EB2498C2AFB1DF8555CB7C1EF89CA5C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>DE132C2A739AD46783858B794AD9EEEA</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>6F219A4367F11919243ABEDBE901877C</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Segment-GoogleAnalytics</string>
+			<key>target</key>
+			<string>859E063BB03DDB2C5D9A99DB427478EA</string>
+			<key>targetProxy</key>
+			<string>BCF9B107370736590CF156865DDE2E24</string>
+		</dict>
+		<key>6FF568E538D78F99F2EA1ED159B99766</key>
+		<dict>
+			<key>fileRef</key>
+			<string>666C57509FA1B9FD91574E36B4521896</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>70545E4EA86C6E593A2A9F6731DA8F6D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8B073B349D98A4F02811E8A0E77D58BC</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>70F1E51CF39B72EA90BB9F19C3056733</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1ECBFFA672D10773C52B801D99B88FBE</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>7146A0979739F3A21FF50C0953C8D2A0</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SpectaTypes.h</string>
+			<key>path</key>
+			<string>Specta/Specta/SpectaTypes.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7220860A5419A2390473421A11D2A3A0</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>91716783ABA4BA9B79B0501A0CDB59D9</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>7436C602BB1CA7C91560C28DE749357B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>3E4490F950B5EC6EAC20E6BD37E9C14E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>74707D5ABEC55B3084F52C40A4227B06</key>
+		<dict>
+			<key>fileRef</key>
+			<string>4DC954F6F5AB56AE2D793E9ACA45624D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>74D3ACC6B6BEF1EDD07AE51CA1B7E60D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>archive.ar</string>
+			<key>name</key>
+			<string>libGoogleAnalytics.a</string>
+			<key>path</key>
+			<string>Libraries/libGoogleAnalytics.a</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>76331E71086C8CD5118A69B046D8F0FB</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8499D866C1900FB26A437C8FE263DB5E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>7669417A2998C97CD154ABD987C5334E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SEGSegmentIntegration.m</string>
+			<key>path</key>
+			<string>Pod/Classes/Internal/SEGSegmentIntegration.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>76948DA1B8E447BB5BAEBFBBF91D38EF</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SPTCallSite.m</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTCallSite.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>76FDA2EF06A82D029BE55F779402A351</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+contain.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+contain.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>779CFE8771E1EF63F1313ABEBCECAA4A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2743254252516E0A88873C5402573C5B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>77BE6CC9369C45EFBC1FD1A322BFD975</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Analytics</string>
+			<key>target</key>
+			<string>E703EF8141AB3D56D46182B4EA5FB571</string>
+			<key>targetProxy</key>
+			<string>2CDEF66D198FA82D47E8C5065823C834</string>
+		</dict>
+		<key>789F69996FFDE3AECA5AF9C317B256B6</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SPTCallSite.h</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTCallSite.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>799B3B17E7D0BC474B86DA58267CBEE4</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+raise.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+raise.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>79C247F75A75B96048791BEBE10B0B03</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+haveCountOf.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+haveCountOf.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7A3C46FD9F45AE288519FB8A642FB17D</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>003E1FF25B624503C0B7DE8E09FFCD2E</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Specta/Specta-prefix.pch</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PRIVATE_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>7AC91F55DAAA2F0223A97BEFF8BCAF68</key>
+		<dict>
+			<key>fileRef</key>
+			<string>6A1C939D28292C3A5B4011F361790762</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>7C1E9D81E228F9B07251DEEB275F4744</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>Specta.h</string>
+			<key>path</key>
+			<string>Specta/Specta/Specta.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7DB346D0F39D3F0E887471402A8071AB</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>BA6428E9F66FD5A23C0A2E06ED26CD2F</string>
+				<string>6EAF2E95795D983AC7CE49F822DA3827</string>
+				<string>433CD3331B6C3787F473C941B61FC68F</string>
+				<string>14327F0AB7B3F21ADB2B69A7DCA9CAF8</string>
+				<string>44727FC65C18BECDF363D9F7AE53FC15</string>
+				<string>E1611D850FB6C6C54941631CDAB3A5A7</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7ED4DAD1A4FB242A6CE917329C32BDCB</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGSegmentIntegration.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Internal/SEGSegmentIntegration.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7F99F346CEC7597BC4AD63F1E966D594</key>
+		<dict>
+			<key>fileRef</key>
+			<string>CA511D8C5CCB276C4F4E948BD4A5939F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>7FD3BC43A6C31A97BF932D9F18311E76</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SpectaUtility.h</string>
+			<key>path</key>
+			<string>Specta/Specta/SpectaUtility.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>7FEE0E8D094D7BCCAC7129473EE05ADC</key>
+		<dict>
+			<key>fileRef</key>
+			<string>799B3B17E7D0BC474B86DA58267CBEE4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>803929AB0EC5B999F71365235E2FC569</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>GAITracker.h</string>
+			<key>path</key>
+			<string>Headers/Public/GAITracker.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8059E5674B08670B0A002D564FFABF44</key>
+		<dict>
+			<key>fileRef</key>
+			<string>277DE8AADE10662CAE402205802458BA</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>80C8D930FC5B078021D346DAB2B72B81</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+raiseWithReason.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+raiseWithReason.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>81B495005EBD1E18D49D930C9F0DE1A4</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SEGReachability.m</string>
+			<key>path</key>
+			<string>Pod/Classes/Internal/SEGReachability.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8499D866C1900FB26A437C8FE263DB5E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+endWith.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+endWith.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8559F319F13540B66A857B6CFF67836E</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>1FA53FB61D99D37B11CF3D7568F1FAA2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>855FF2069FE35409211B068CF74D1BC9</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>path</key>
+			<string>Pods-Segment-GoogleAnalytics_Example-acknowledgements.markdown</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>859E063BB03DDB2C5D9A99DB427478EA</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>B1ABFB242198C5E38A6728EA931D52C8</string>
+			<key>buildPhases</key>
+			<array>
+				<string>F8A3174F1370ED9A57F94C3ED212C70E</string>
+				<string>25B28C645D7048EE8533D648851B36DE</string>
+				<string>191BD56D6E43E54A25DA0A5C308A2752</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>EFA2F8627C19B0786403860E75168CF4</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Segment-GoogleAnalytics</string>
+			<key>productName</key>
+			<string>Segment-GoogleAnalytics</string>
+			<key>productReference</key>
+			<string>41DDF8C028B6E5026AD5CC5BAD2AAA3B</string>
+			<key>productType</key>
+			<string>com.apple.product-type.library.static</string>
+		</dict>
+		<key>869F6CDA9DFD53454C106CBA668F580E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPUnsupportedObject.h</string>
+			<key>path</key>
+			<string>Expecta/EXPUnsupportedObject.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>86F591E03C6A2C071821D67283CFF54D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beCloseTo.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beCloseTo.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>872948DAF79618AD725E0BF364E5DDD4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>5F5D27B4777037698149BC2D9793405F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>8811C2CFB32EDC145242E31D1D6000C3</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>libSpecta.a</string>
+			<key>path</key>
+			<string>libSpecta.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>8857DA884D845E55149E2D0721FE2C41</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGIdentifyPayload.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Integrations/SEGIdentifyPayload.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8A87FB401B93066DD8C85AAB9CDBC11A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>F2848ECE86915EED9032636E866D125F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8A96A585C0DF065295FEE69BB53944E9</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beKindOf.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beKindOf.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8AF5B07DCDCBE1BC22042D777A38B464</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beTruthy.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beTruthy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8B073B349D98A4F02811E8A0E77D58BC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beTruthy.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beTruthy.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8B1B60B7C24DCFAC0081FE5432C10942</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A35484475812F6496D912E772717EE78</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8C65EAD9F4779A546336645EC8E51355</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGAnalyticsUtils.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Internal/SEGAnalyticsUtils.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8DC6005FC38AC1939F82F6C1FB9A2E36</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+postNotification.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+postNotification.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8DDB38718F95D76871BD12B66C61FB29</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>GAIEcommerceProduct.h</string>
+			<key>path</key>
+			<string>Headers/Public/GAIEcommerceProduct.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8DF90D623F7F9015EEE9F1D7FEE7E053</key>
+		<dict>
+			<key>fileRef</key>
+			<string>463DA29EAC33AE0F642267ADB9876178</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>8F674582EE71972EE60EFD96C1F173D5</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C57F3C0E6485F86FF3B4BBF6323AA0F2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>8F8B382D1231AE6FCA478E3C79F036AD</key>
+		<dict>
+			<key>fileRef</key>
+			<string>91A2E492978527A73B3C4C3DD6B91C97</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9019F9233E2A8B04A82C1B8D0274F09F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>95513FEBF6B22034689515724F049996</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>901C95FA513F8BEC6992EE457A527DE1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8C65EAD9F4779A546336645EC8E51355</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>90552A900C20BA732E285A6C8CDB4660</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beInstanceOf.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beInstanceOf.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>90652227DA6C2B4C6C8E843F2F8BAC21</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>ExpectaObject.m</string>
+			<key>path</key>
+			<string>Expecta/ExpectaObject.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>90A6E1569ECE25A96D932D7CB0456A00</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+equal.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+equal.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>915945EFDF699B928B3BE5F473CDA320</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>503BF36CDAFC3DE4E6862924EFF5DF1D</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>91716783ABA4BA9B79B0501A0CDB59D9</key>
+		<dict>
+			<key>fileRef</key>
+			<string>E351727CD07BB90B2A3CAE2C2433F6C5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>91A2E492978527A73B3C4C3DD6B91C97</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SEGAnalytics.m</string>
+			<key>path</key>
+			<string>Pod/Classes/SEGAnalytics.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9317CA06C334C88F084CD88BF04618ED</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGBluetooth.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Internal/SEGBluetooth.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>95513FEBF6B22034689515724F049996</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beSupersetOf.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beSupersetOf.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>956FB3AB698AF3DA776A9F24AA79C229</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EF3EB8C9DCBBEF065C7190483B798529</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>97E91EC237B8623D895DBF6092034AD7</key>
+		<dict>
+			<key>fileRef</key>
+			<string>0632D8C7A85E2AB40699726F5382E847</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>97F182F971933BFEF29A646F7D22423E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGGroupPayload.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Integrations/SEGGroupPayload.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>986E88CA93CED9C4B4963349457B2AA8</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>libPods-Segment-GoogleAnalytics_Tests.a</string>
+			<key>path</key>
+			<string>libPods-Segment-GoogleAnalytics_Tests.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>9880405C14D519BEE71EC813F6A7BBF9</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>9E7AED6529044F5A3F1798885FA0EB66</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Segment-GoogleAnalytics/Segment-GoogleAnalytics-prefix.pch</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PRIVATE_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>98A22457F5E28CAF0B7E113A6D4142A1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2837272F75DD845EF2A91B94FA9E38AA</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>98AF2EF29263F6E5F2917A01134D91A1</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Pods-Segment-GoogleAnalytics_Example-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>98DF4A3BC1F64C0C071727A6031AF527</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>F7DE9BBD243370BF8EFFF25D7E85CD4C</string>
+				<string>1090ADEE4E406645BC0603EF794F19AE</string>
+				<string>51F974C6782C68F90D278FCEA769A59E</string>
+				<string>99AF585D638505D532A2B91329682F8E</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Classes</string>
+			<key>path</key>
+			<string>Classes</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9936109944D13524536A31583D20FC5C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>Pods-Segment-GoogleAnalytics_Example-acknowledgements.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>99AF585D638505D532A2B91329682F8E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>SEGGoogleAnalyticsIntegrationFactory.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>99BD68DAAEB1D209D3294D30352A9B1C</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>4F399E73BB1F0DA1C2966C111EA9C7EE</string>
+				<string>00AA78757DDCD095BADCC948F96D9918</string>
+				<string>666C57509FA1B9FD91574E36B4521896</string>
+				<string>067AB382C6EAF94F9525C2D3E798EA89</string>
+				<string>F39B31E5EECC1F9DF23BDFF4244FE860</string>
+				<string>E200A1F712D8C70CEE0ABE0ACDE4D904</string>
+				<string>CAAE62E8DB86653476BDEDF0B6664DBD</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Pods-Segment-GoogleAnalytics_Tests</string>
+			<key>path</key>
+			<string>Target Support Files/Pods-Segment-GoogleAnalytics_Tests</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9A3BD1002DD3D3877A0AD6DC83B9AFC7</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SPTExample.m</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTExample.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9A7702F7DB899DC0B318CF2119620155</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>D28FB9DCE5CE0170C17A7A54A9F819B3</string>
+			<key>buildPhases</key>
+			<array>
+				<string>16EC47C0D8BADA487C115973D26718A7</string>
+				<string>DE3FAE515E840D135753AFEE65CCA8A8</string>
+				<string>A0599526CEAEE33A2D986C0B1B06A949</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Specta</string>
+			<key>productName</key>
+			<string>Specta</string>
+			<key>productReference</key>
+			<string>8811C2CFB32EDC145242E31D1D6000C3</string>
+			<key>productType</key>
+			<string>com.apple.product-type.library.static</string>
+		</dict>
+		<key>9B546D0F895D9B5A8316B948CEE95C77</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8A96A585C0DF065295FEE69BB53944E9</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>9E7AED6529044F5A3F1798885FA0EB66</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Segment-GoogleAnalytics.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F4084E6D71859700239E620D3D1BA2D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>568C2BF10FCA51F625ECC214C3A9D520</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>9F4BA3995289C6236CF8558CE17CD670</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>74D3ACC6B6BEF1EDD07AE51CA1B7E60D</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>9F56505149E55909F48A9E238EC226EC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>GAIEcommercePromotion.h</string>
+			<key>path</key>
+			<string>Headers/Public/GAIEcommercePromotion.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A0599526CEAEE33A2D986C0B1B06A949</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>2D881B10160E6AA5B265F69CA2F53159</string>
+				<string>CCCD4FA4F4339DED24A487A9312D9526</string>
+				<string>475BBFA6E99B39CB8429C0B71972E445</string>
+				<string>D3C948582E14C4F4A6D87738C5EB0EC1</string>
+				<string>F40B16934B552AC428855EC01D39473C</string>
+				<string>6656F35498E5573ED9F890D8B828B828</string>
+				<string>DA51317333A94F4A9B3B1FF0A1DF71EF</string>
+				<string>43659A5034D2F6C8510DDC52EFD7B7CA</string>
+				<string>70F1E51CF39B72EA90BB9F19C3056733</string>
+				<string>4B0EA949E5076B09ED0B24C22053F953</string>
+				<string>3D508F6B13170EC5036ECEEECB475BA4</string>
+				<string>C186082DC500722CB26121EAB9F92126</string>
+				<string>605CADFBD63A01EDAA5A251B60B2C6AA</string>
+				<string>B7D89DBEEF4C2A2165C2A1E127947D9A</string>
+				<string>2CDDCDCA361D583C58B28EF022F8387E</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>A1FCE77270936EE316746356E3A413E1</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+conformTo.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+conformTo.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A26F992E8831118311F3DB7CB830595A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>80C8D930FC5B078021D346DAB2B72B81</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>A2A91F93C68DAE8C18FE53F6EA15D54D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>81B495005EBD1E18D49D930C9F0DE1A4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>A35484475812F6496D912E772717EE78</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SEGSegmentIntegrationFactory.m</string>
+			<key>path</key>
+			<string>Pod/Classes/Internal/SEGSegmentIntegrationFactory.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A4644EDA4C4D6F333FB54B441CB67E93</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>2F501FE84845EAD97B9087DAFCBBEE0E</string>
+			<key>remoteInfo</key>
+			<string>Expecta</string>
+		</dict>
+		<key>A5040B544FBFCCA344AF6F5D7ADDFADF</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+respondTo.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+respondTo.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A65C491577A425AF82C53F4A40A0A24B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>5A2F6E1360B9C61485920F5D5473A974</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>A6854D311D55E2BBD8BFCE4E82DF3EA9</key>
+		<dict>
+			<key>fileRef</key>
+			<string>661A7213AFBB8E769759DBE86DCAE8EB</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>A70CDAD61F90AC503C7D04CC22DA2923</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>STRIP_INSTALLED_PRODUCT</key>
+				<string>NO</string>
+				<key>SYMROOT</key>
+				<string>${SRCROOT}/../build</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>A7141BC83638F4B38D4D312BAE3BDAC4</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C582A29AB08E63C474831C4D63A9B123</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>A76D476E5FC248FFF04B019CFE53E21A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+contain.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+contain.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A78EC25004EE56F06223E13322CB2FA6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>20931BF25C1C314AD48793C2B3EFB1DD</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>A8490A46CB5206BCA5F90FCFBA2D731E</key>
+		<dict>
+			<key>fileRef</key>
+			<string>305B6661988E84D5D0C3B158B277BEAC</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>A8ABFA4EFC8E5E19332345AE253640A0</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>archive.ar</string>
+			<key>name</key>
+			<string>libAdIdAccessLibrary.a</string>
+			<key>path</key>
+			<string>Libraries/libAdIdAccessLibrary.a</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A8BCFD4057C083FF8B2B91CAA2A517AD</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-Segment-GoogleAnalytics_Example-frameworks.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>A9B2D68316EF35682E3B24DD33C44B66</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beInstanceOf.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beInstanceOf.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>AA7B402D31D86AE5E3DD083408311FF1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>4C84E03C3810D3CB1B6F36216A398A2E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>AA87D29C4C4D9CB70A5BB9010C93E406</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SEGAliasPayload.m</string>
+			<key>path</key>
+			<string>Pod/Classes/Integrations/SEGAliasPayload.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>AAAFAFFB150A80628C686DDD8D642B9D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>XCTestCase+Specta.m</string>
+			<key>path</key>
+			<string>Specta/Specta/XCTestCase+Specta.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>AAE75938ED3DD46BC00352B82D7CA890</key>
+		<dict>
+			<key>fileRef</key>
+			<string>FE99B615AB863FEF83FD39F59E2A939D</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>AB1D6408D48F6ECF3FCE553BE73961F5</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2E91479DE86808F686A59942FC879D8E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>ABF9EC2DB5BBC2E9086DA001DAFE23F0</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Segment-GoogleAnalytics</string>
+			<key>target</key>
+			<string>859E063BB03DDB2C5D9A99DB427478EA</string>
+			<key>targetProxy</key>
+			<string>30F56C861EE89640CE6C9F59CA056520</string>
+		</dict>
+		<key>AD6791D14732A3C17164F61CC72FFB0D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>518A7131AD41523DC00501D702A1EF88</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>B038AD02D30EC17B9D23EB9D1487382C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>76948DA1B8E447BB5BAEBFBBF91D38EF</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>B09EF0FD07655A036EF25A09252EC9A9</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1701C01002B6CA774E41013BCDCF6F72</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>B1ABFB242198C5E38A6728EA931D52C8</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>F30A41276DE3EE0553B4749F788F4B8A</string>
+				<string>9880405C14D519BEE71EC813F6A7BBF9</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>B309BC0D714443A4A815F45FECB8AAB1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2C9CEECF04FC9560D547C3380931D78B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>B33234F432A72D5E8B65694AE937B78F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>61D10D4273167662735D83D780C56F89</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>B4B89A8180E266D6FD109356EBE762DA</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPDoubleTuple.h</string>
+			<key>path</key>
+			<string>Expecta/EXPDoubleTuple.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B5F7A213B1C490590EFAB25DF6AFD48A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>11DDFBEEBD749A88975C8606A445C015</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>B658C2B4FB8A46E92A154CFF1291537A</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SPTTestSuite.h</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTTestSuite.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B7D89DBEEF4C2A2165C2A1E127947D9A</key>
+		<dict>
+			<key>fileRef</key>
+			<string>55345A779F22C7147507AC695CE3B85B</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>B87904014217EC9142A60100E6D363E3</key>
+		<dict>
+			<key>fileRef</key>
+			<string>0D32FAD33571B227BE06BBB6E80444A8</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>B9ADDA29B749820D119249DA1929589E</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-Segment-GoogleAnalytics_Example-resources.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>B9BD17A05F5CCA4B178E0E0DC065D6D5</key>
+		<dict>
+			<key>fileRef</key>
+			<string>9A3BD1002DD3D3877A0AD6DC83B9AFC7</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BA6428E9F66FD5A23C0A2E06ED26CD2F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text</string>
+			<key>name</key>
+			<string>Podfile</string>
+			<key>path</key>
+			<string>../Podfile</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+			<key>xcLanguageSpecificationIdentifier</key>
+			<string>xcode.lang.ruby</string>
+		</dict>
+		<key>BC021CC978BE68B2BE0A690878FB54AF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2E0733A0038EE5736FF18B5A63792DA6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>BCF9B107370736590CF156865DDE2E24</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>859E063BB03DDB2C5D9A99DB427478EA</string>
+			<key>remoteInfo</key>
+			<string>Segment-GoogleAnalytics</string>
+		</dict>
+		<key>BD30B724A71CF5D6E93805B7615EC79C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C86EDDCE44ACD911BBDB34FA398F8A83</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>BDA0B809F5CE67054059064E81CBAF5F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>NSValue+Expecta.h</string>
+			<key>path</key>
+			<string>Expecta/NSValue+Expecta.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C0243D80A39E6D84988415B3206EBCF0</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>libAnalytics.a</string>
+			<key>path</key>
+			<string>libAnalytics.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>C08BC501533D0ED2041A5BEDAC7BF10A</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>003E1FF25B624503C0B7DE8E09FFCD2E</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Specta/Specta-prefix.pch</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PRIVATE_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>C08D1B602D6625CEA47ACD780698D832</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>CAAE62E8DB86653476BDEDF0B6664DBD</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>NO</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>C186082DC500722CB26121EAB9F92126</key>
+		<dict>
+			<key>fileRef</key>
+			<string>41D48B8BD24D516FA56686BDD2A113C2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>C1A93C3D14968665C68BD6069241F78C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPBlockDefinedMatcher.m</string>
+			<key>path</key>
+			<string>Expecta/EXPBlockDefinedMatcher.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C1C171166E9393E8C112CDC72CDEBF13</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SpectaDSL.m</string>
+			<key>path</key>
+			<string>Specta/Specta/SpectaDSL.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C258607F1A902F6E3358877275B1C45D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>ExpectaSupport.m</string>
+			<key>path</key>
+			<string>Expecta/ExpectaSupport.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C2BFF99EB859FD7056CF72C4850693D1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A1FCE77270936EE316746356E3A413E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>C345B90819C4CE033B07926CFEEF9644</key>
+		<dict>
+			<key>fileRef</key>
+			<string>51F974C6782C68F90D278FCEA769A59E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>C455239AD9C4D14DE61DD20A51A59635</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>9E7AED6529044F5A3F1798885FA0EB66</string>
+				<string>D671DB178CE02AEA19CBF062C3596692</string>
+				<string>04CCA4E932E4555FE104E08F5A1F899A</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>Example/Pods/Target Support Files/Segment-GoogleAnalytics</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C4E98ABEAC39F16F3D1D5D53F15A2F9F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beFalsy.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beFalsy.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C57F3C0E6485F86FF3B4BBF6323AA0F2</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beGreaterThan.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beGreaterThan.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C582A29AB08E63C474831C4D63A9B123</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beginWith.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beginWith.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C6671739E8C5904113586F8BEBBC9780</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2C9B4D847287245CC715A02DD0F307E1</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>C6ABA54126ECDD4523DA27371E0E9474</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-Segment-GoogleAnalytics_Example.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C6AD7852D34E8A80DFF3B8376BDE812F</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>8DF90D623F7F9015EEE9F1D7FEE7E053</string>
+				<string>6A4E3ACA285A21392936C110E7EC91F0</string>
+				<string>3A013F13122CDB8EE962F8CB7C6FCC8E</string>
+				<string>A6854D311D55E2BBD8BFCE4E82DF3EA9</string>
+				<string>081F2104425CDCB0915354E2FBD7E24E</string>
+				<string>7AC91F55DAAA2F0223A97BEFF8BCAF68</string>
+				<string>2A17721E4A81DB608CA6D4FB6F0ADAFB</string>
+				<string>341D7536159B52F41598F730CC45D548</string>
+				<string>07282695806D1DFBF187BFA004D80641</string>
+				<string>A8490A46CB5206BCA5F90FCFBA2D731E</string>
+				<string>AA7B402D31D86AE5E3DD083408311FF1</string>
+				<string>F4CA468B5A9F8FF2A4DB8B236A8E71BF</string>
+				<string>021C50274FF43A6F07E119D572C3ACB6</string>
+				<string>8F674582EE71972EE60EFD96C1F173D5</string>
+				<string>3E463E2B6917D9AA08A03BA8A8E74A18</string>
+				<string>AB1D6408D48F6ECF3FCE553BE73961F5</string>
+				<string>D42799488F38F2DB8A580730CEE13CE6</string>
+				<string>97E91EC237B8623D895DBF6092034AD7</string>
+				<string>9B546D0F895D9B5A8316B948CEE95C77</string>
+				<string>DFF580AE359407E841BA8D8DDCE6E299</string>
+				<string>EE52A320EC3155B114104E06396D1B59</string>
+				<string>74707D5ABEC55B3084F52C40A4227B06</string>
+				<string>14C609D8F203FD45194E93997EFF744E</string>
+				<string>9019F9233E2A8B04A82C1B8D0274F09F</string>
+				<string>70545E4EA86C6E593A2A9F6731DA8F6D</string>
+				<string>2945FAA75C956DD6A541EB51E42E6899</string>
+				<string>02C7E3EC1E1DFDD7046BD26A67E92686</string>
+				<string>76331E71086C8CD5118A69B046D8F0FB</string>
+				<string>430CE433DB59FE090A8CC6AFCFA43337</string>
+				<string>237FB063FB365119546C7B5006224F3B</string>
+				<string>C98F5401E5C1AB6512BE50C3B7CEA9BF</string>
+				<string>339A0C1BFF72397A705959E03877DDDB</string>
+				<string>AAE75938ED3DD46BC00352B82D7CA890</string>
+				<string>6EB2498C2AFB1DF8555CB7C1EF89CA5C</string>
+				<string>E867CBF850D20C314BF4BD790432455D</string>
+				<string>6924E116731D7079958063A3EE0781ED</string>
+				<string>4231743B6C143BDB4A5FBB032E6D3799</string>
+				<string>956FB3AB698AF3DA776A9F24AA79C229</string>
+				<string>60D3CCEB5B53542228790ABD8885AF42</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>C6B2685864B008D5854B7554B05FE815</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGIntegration.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Integrations/SEGIntegration.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C86EDDCE44ACD911BBDB34FA398F8A83</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beSubclassOf.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beSubclassOf.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C90EFAB73AD4A25DD1A311ACFB030AE8</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beKindOf.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beKindOf.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>C98F5401E5C1AB6512BE50C3B7CEA9BF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>39E9492F7292B43EF5DE6007F51DA0EC</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>C9E85A65EFBEA8CB9F441C68B3E492C1</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beGreaterThanOrEqualTo.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beGreaterThanOrEqualTo.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CA511D8C5CCB276C4F4E948BD4A5939F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SEGAnalyticsRequest.m</string>
+			<key>path</key>
+			<string>Pod/Classes/Internal/SEGAnalyticsRequest.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CAAE62E8DB86653476BDEDF0B6664DBD</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-Segment-GoogleAnalytics_Tests.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CB08C9C83ABDBE55762A423ED48491EF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>17A3F1607267A4CD0D8B76C017299F78</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>CBA9906B41948B0D8CAEE6AE031F3982</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>C6ABA54126ECDD4523DA27371E0E9474</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>MACH_O_TYPE</key>
+				<string>staticlib</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PODS_ROOT</key>
+				<string>$(SRCROOT)</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>CBC8E95BD4789904887E8E44506F2E19</key>
+		<dict>
+			<key>fileRef</key>
+			<string>E351727CD07BB90B2A3CAE2C2433F6C5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>CBFEA0C6D4EBA470E98B90635BAB38B2</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Analytics-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CCCD4FA4F4339DED24A487A9312D9526</key>
+		<dict>
+			<key>fileRef</key>
+			<string>4511AE2A42381FF1A3B3C12144FC0C0E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>CCDE6708F49E9734E245E14F26FEC611</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>GAI.h</string>
+			<key>path</key>
+			<string>Headers/Public/GAI.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CF6E7D5EB1BE0988C685F173F5871BC8</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>GAILogger.h</string>
+			<key>path</key>
+			<string>Headers/Public/GAILogger.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>CF95446EA555B49150EA7270096D78B2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C1A93C3D14968665C68BD6069241F78C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>CFAE41FD7F6F5C7D8E508C03208FFF59</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGAnalytics.h</string>
+			<key>path</key>
+			<string>Pod/Classes/SEGAnalytics.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D0B9C9663686AD4EC06FA9062E80A8F0</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-Segment-GoogleAnalytics_Example.release.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D1CB69C27633FCC3576F1778EFC09B7D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SEGLocation.h</string>
+			<key>path</key>
+			<string>Pod/Classes/Internal/SEGLocation.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D28FB9DCE5CE0170C17A7A54A9F819B3</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>7A3C46FD9F45AE288519FB8A642FB17D</string>
+				<string>C08BC501533D0ED2041A5BEDAC7BF10A</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>D327A699D86B9304B2D3FEAB534333DC</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>SPTExample.h</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTExample.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D3C948582E14C4F4A6D87738C5EB0EC1</key>
+		<dict>
+			<key>fileRef</key>
+			<string>7FD3BC43A6C31A97BF932D9F18311E76</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>D41D8CD98F00B204E9800998ECF8427E</key>
+		<dict>
+			<key>attributes</key>
+			<dict>
+				<key>LastSwiftUpdateCheck</key>
+				<string>0700</string>
+				<key>LastUpgradeCheck</key>
+				<string>0700</string>
+			</dict>
+			<key>buildConfigurationList</key>
+			<string>2D8E8EC45A3A1A1D94AE762CB5028504</string>
+			<key>compatibilityVersion</key>
+			<string>Xcode 3.2</string>
+			<key>developmentRegion</key>
+			<string>English</string>
+			<key>hasScannedForEncodings</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXProject</string>
+			<key>knownRegions</key>
+			<array>
+				<string>en</string>
+			</array>
+			<key>mainGroup</key>
+			<string>7DB346D0F39D3F0E887471402A8071AB</string>
+			<key>productRefGroup</key>
+			<string>44727FC65C18BECDF363D9F7AE53FC15</string>
+			<key>projectDirPath</key>
+			<string></string>
+			<key>projectReferences</key>
+			<array/>
+			<key>projectRoot</key>
+			<string></string>
+			<key>targets</key>
+			<array>
+				<string>E703EF8141AB3D56D46182B4EA5FB571</string>
+				<string>2F501FE84845EAD97B9087DAFCBBEE0E</string>
+				<string>1752D706BA25FF27E5712204C17F8745</string>
+				<string>58EB5E47E144CBC4F4FE00C8F2B1AB95</string>
+				<string>859E063BB03DDB2C5D9A99DB427478EA</string>
+				<string>9A7702F7DB899DC0B318CF2119620155</string>
+			</array>
+		</dict>
+		<key>D42799488F38F2DB8A580730CEE13CE6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A9B2D68316EF35682E3B24DD33C44B66</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>D58B97E6820E236C055063572F1E32A2</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>name</key>
+			<string>libPods-Segment-GoogleAnalytics_Example.a</string>
+			<key>path</key>
+			<string>libPods-Segment-GoogleAnalytics_Example.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>D671DB178CE02AEA19CBF062C3596692</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Segment-GoogleAnalytics-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D69A20A8681184C1F18D69A2BB644717</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>E3D9551407884464577E58647CC2CDDE</string>
+				<string>18D2D1F8D8D2C1AB3ACA586DE2F5C814</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>D6E18A324EC0EBA79E68C000D042CCB0</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>003E1FF25B624503C0B7DE8E09FFCD2E</string>
+				<string>EEA295B5F005DA5BE3281CE44E4D995D</string>
+				<string>578995B5D7A1B89485396FD3F985F3C1</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/Specta</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D7A891CE610ABA3D2BD4D00D054B959D</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>463DA29EAC33AE0F642267ADB9876178</string>
+				<string>C1A93C3D14968665C68BD6069241F78C</string>
+				<string>195673BC1D4EBD3D604A447FFEF80200</string>
+				<string>B4B89A8180E266D6FD109356EBE762DA</string>
+				<string>F3165B876D08CD102EA891025959EB19</string>
+				<string>661A7213AFBB8E769759DBE86DCAE8EB</string>
+				<string>E128AD4B837926B3A5A036D8E8DFECAD</string>
+				<string>90652227DA6C2B4C6C8E843F2F8BAC21</string>
+				<string>6A1C939D28292C3A5B4011F361790762</string>
+				<string>C258607F1A902F6E3358877275B1C45D</string>
+				<string>EDB92F0DECBE15130358426D5213D6C8</string>
+				<string>0D61BFA15E780468CFF692FA8FFE5AFE</string>
+				<string>56BBCF71F950D6191CD6B1B91A85FA82</string>
+				<string>2743254252516E0A88873C5402573C5B</string>
+				<string>DE73CB6561F92F5CB79F28F7A4303749</string>
+				<string>305B6661988E84D5D0C3B158B277BEAC</string>
+				<string>E3554BD7A107F9879E5EB62B4F8C2A35</string>
+				<string>03F690173163BA691C98E1D242100544</string>
+				<string>4C84E03C3810D3CB1B6F36216A398A2E</string>
+				<string>86F591E03C6A2C071821D67283CFF54D</string>
+				<string>C4E98ABEAC39F16F3D1D5D53F15A2F9F</string>
+				<string>4D12FAE56109712094DA78D38B05DA2C</string>
+				<string>22FAD7D819C780BD3941E8361C9DE50E</string>
+				<string>C582A29AB08E63C474831C4D63A9B123</string>
+				<string>C57F3C0E6485F86FF3B4BBF6323AA0F2</string>
+				<string>17A3F1607267A4CD0D8B76C017299F78</string>
+				<string>C9E85A65EFBEA8CB9F441C68B3E492C1</string>
+				<string>518A7131AD41523DC00501D702A1EF88</string>
+				<string>2E91479DE86808F686A59942FC879D8E</string>
+				<string>5A2F6E1360B9C61485920F5D5473A974</string>
+				<string>A9B2D68316EF35682E3B24DD33C44B66</string>
+				<string>90552A900C20BA732E285A6C8CDB4660</string>
+				<string>0632D8C7A85E2AB40699726F5382E847</string>
+				<string>3E4490F950B5EC6EAC20E6BD37E9C14E</string>
+				<string>8A96A585C0DF065295FEE69BB53944E9</string>
+				<string>C90EFAB73AD4A25DD1A311ACFB030AE8</string>
+				<string>2494E91B1F913E639B70B22D66D6B52F</string>
+				<string>2C9B4D847287245CC715A02DD0F307E1</string>
+				<string>EC523F5B18127D76F5586636012C547F</string>
+				<string>0230190DDFC91DA732D8624EF3C54A9E</string>
+				<string>4DC954F6F5AB56AE2D793E9ACA45624D</string>
+				<string>4075E3A20D226B9478030380B33E3EEE</string>
+				<string>6A2147C8C8E0A818D9BC42DC2F23709B</string>
+				<string>C86EDDCE44ACD911BBDB34FA398F8A83</string>
+				<string>95513FEBF6B22034689515724F049996</string>
+				<string>ED4F564CFDAA4CBE9BBFBECE5695AA05</string>
+				<string>8B073B349D98A4F02811E8A0E77D58BC</string>
+				<string>8AF5B07DCDCBE1BC22042D777A38B464</string>
+				<string>2D88ACEFC22E13FCF6F27A591CCC1D53</string>
+				<string>A1FCE77270936EE316746356E3A413E1</string>
+				<string>76FDA2EF06A82D029BE55F779402A351</string>
+				<string>A76D476E5FC248FFF04B019CFE53E21A</string>
+				<string>8499D866C1900FB26A437C8FE263DB5E</string>
+				<string>61D10D4273167662735D83D780C56F89</string>
+				<string>90A6E1569ECE25A96D932D7CB0456A00</string>
+				<string>277DE8AADE10662CAE402205802458BA</string>
+				<string>FAE4AA155A2514A44DCF02CDE86885CF</string>
+				<string>79C247F75A75B96048791BEBE10B0B03</string>
+				<string>39E9492F7292B43EF5DE6007F51DA0EC</string>
+				<string>FF44A189D47E0B1CB7FA13DE72A685BB</string>
+				<string>8DC6005FC38AC1939F82F6C1FB9A2E36</string>
+				<string>19BA3A4E9AB74D50BA74D05C5A3A497B</string>
+				<string>FE99B615AB863FEF83FD39F59E2A939D</string>
+				<string>799B3B17E7D0BC474B86DA58267CBEE4</string>
+				<string>DE132C2A739AD46783858B794AD9EEEA</string>
+				<string>80C8D930FC5B078021D346DAB2B72B81</string>
+				<string>A5040B544FBFCCA344AF6F5D7ADDFADF</string>
+				<string>4F7810CA7C3360CA27786A4189D1F13A</string>
+				<string>869F6CDA9DFD53454C106CBA668F580E</string>
+				<string>66A04F37AA8446E5F76E605B220607FA</string>
+				<string>EF3EB8C9DCBBEF065C7190483B798529</string>
+				<string>BDA0B809F5CE67054059064E81CBAF5F</string>
+				<string>5F5D27B4777037698149BC2D9793405F</string>
+				<string>6D00BA5555F1E5B354F14BDC1A0274B9</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Expecta</string>
+			<key>path</key>
+			<string>Expecta</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>D99400BFB9A624D8E051FED7A1BDF315</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SEGTrackPayload.m</string>
+			<key>path</key>
+			<string>Pod/Classes/Integrations/SEGTrackPayload.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DA51317333A94F4A9B3B1FF0A1DF71EF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>D327A699D86B9304B2D3FEAB534333DC</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>DAC08D09C7E4411C8B01CD2FCFCD247B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>6BD6385C8632CDBB33C3F694D32D44AC</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>DD7BED725086CF410512F736DE7AA95B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>3AD7BB555A10EBB24F11166027FCCB24</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>DDA0131B5E07737BB02250EC8E73A2F6</key>
+		<dict>
+			<key>fileRef</key>
+			<string>E351727CD07BB90B2A3CAE2C2433F6C5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>DE132C2A739AD46783858B794AD9EEEA</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+raiseWithReason.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+raiseWithReason.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DE3FAE515E840D135753AFEE65CCA8A8</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>FBBEEFC1F77A002E76A2E9CBC801BABF</string>
+				<string>F9F824608D10EAF566AE7C2C9AD73CC5</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>DE73CB6561F92F5CB79F28F7A4303749</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatcher.h</string>
+			<key>path</key>
+			<string>Expecta/EXPMatcher.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>DFF580AE359407E841BA8D8DDCE6E299</key>
+		<dict>
+			<key>fileRef</key>
+			<string>2494E91B1F913E639B70B22D66D6B52F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>E06376455C1D5E45B97ACDC5438FC15B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>4075E3A20D226B9478030380B33E3EEE</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>E128AD4B837926B3A5A036D8E8DFECAD</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>ExpectaObject.h</string>
+			<key>path</key>
+			<string>Expecta/ExpectaObject.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E1611D850FB6C6C54941631CDAB3A5A7</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>26EDC865188F93E75C783CD41E307006</string>
+				<string>99BD68DAAEB1D209D3294D30352A9B1C</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Targets Support Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E200A1F712D8C70CEE0ABE0ACDE4D904</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>path</key>
+			<string>Pods-Segment-GoogleAnalytics_Tests.debug.xcconfig</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E2EBD18BA89D3FF648947DF31FA12D44</key>
+		<dict>
+			<key>fileRef</key>
+			<string>4F7810CA7C3360CA27786A4189D1F13A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>E351727CD07BB90B2A3CAE2C2433F6C5</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>Foundation.framework</string>
+			<key>path</key>
+			<string>Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.0.sdk/System/Library/Frameworks/Foundation.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>E3554BD7A107F9879E5EB62B4F8C2A35</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatcherHelpers.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatcherHelpers.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>E3D9551407884464577E58647CC2CDDE</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>558A49FF40959AE7147F14C765269D33</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Analytics/Analytics-prefix.pch</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PRIVATE_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>E617E37B8DE4B930EC91E78E7B804A9C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>1638149FA560B7ED8704012F6E32B010</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>E703EF8141AB3D56D46182B4EA5FB571</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>D69A20A8681184C1F18D69A2BB644717</string>
+			<key>buildPhases</key>
+			<array>
+				<string>EF6D2DF45C8F0BE6ED157435C762B99A</string>
+				<string>7220860A5419A2390473421A11D2A3A0</string>
+				<string>EFC9C5C646400A8B60584BB8E9857236</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>Analytics</string>
+			<key>productName</key>
+			<string>Analytics</string>
+			<key>productReference</key>
+			<string>C0243D80A39E6D84988415B3206EBCF0</string>
+			<key>productType</key>
+			<string>com.apple.product-type.library.static</string>
+		</dict>
+		<key>E867CBF850D20C314BF4BD790432455D</key>
+		<dict>
+			<key>fileRef</key>
+			<string>A5040B544FBFCCA344AF6F5D7ADDFADF</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>E8D41CF69BC7D498C16F3887A021F4BA</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C1C171166E9393E8C112CDC72CDEBF13</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>E9E5EFF4A45283579A977D61C2FEE50C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>GAIEcommerceFields.h</string>
+			<key>path</key>
+			<string>Headers/Public/GAIEcommerceFields.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EB27473B3153D1A32E331F8C3BC98E15</key>
+		<dict>
+			<key>fileRef</key>
+			<string>FCF10D4D8159FFF95CFCDB62577AA8E4</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>EC523F5B18127D76F5586636012C547F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+beLessThanOrEqualTo.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beLessThanOrEqualTo.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>ED4F564CFDAA4CBE9BBFBECE5695AA05</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+beSupersetOf.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+beSupersetOf.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EDB92F0DECBE15130358426D5213D6C8</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPExpect.h</string>
+			<key>path</key>
+			<string>Expecta/EXPExpect.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EE52A320EC3155B114104E06396D1B59</key>
+		<dict>
+			<key>fileRef</key>
+			<string>EC523F5B18127D76F5586636012C547F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>EEA295B5F005DA5BE3281CE44E4D995D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>Specta-dummy.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EF305FCB32346C76431C1202E7AD467B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8857DA884D845E55149E2D0721FE2C41</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>EF3EB8C9DCBBEF065C7190483B798529</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>NSObject+Expecta.h</string>
+			<key>path</key>
+			<string>Expecta/NSObject+Expecta.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>EF6D2DF45C8F0BE6ED157435C762B99A</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>486B65BB914388EA36C58304C6039F1F</string>
+				<string>0EBFCC5B0D8267DB953A68498EC7D758</string>
+				<string>8F8B382D1231AE6FCA478E3C79F036AD</string>
+				<string>7F99F346CEC7597BC4AD63F1E966D594</string>
+				<string>B5F7A213B1C490590EFAB25DF6AFD48A</string>
+				<string>68E10C74572004B18490C31A0757E3B2</string>
+				<string>66ED669D42B1035789CE51D6A5C86EB0</string>
+				<string>B09EF0FD07655A036EF25A09252EC9A9</string>
+				<string>B309BC0D714443A4A815F45FECB8AAB1</string>
+				<string>EB27473B3153D1A32E331F8C3BC98E15</string>
+				<string>A2A91F93C68DAE8C18FE53F6EA15D54D</string>
+				<string>10640AF349457B2280632CECCCA5FE7C</string>
+				<string>3CF85CEBEA5339235C29E19B55D944ED</string>
+				<string>8B1B60B7C24DCFAC0081FE5432C10942</string>
+				<string>02FA0FA148C2B4F13646BCD671C1DC0D</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>EFA2F8627C19B0786403860E75168CF4</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>name</key>
+			<string>Analytics</string>
+			<key>target</key>
+			<string>E703EF8141AB3D56D46182B4EA5FB571</string>
+			<key>targetProxy</key>
+			<string>548C4C3F0491EA8ADB64767E149A8DF5</string>
+		</dict>
+		<key>EFC467B0EE8E1392E489559EAD8220D2</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>DDA0131B5E07737BB02250EC8E73A2F6</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>EFC9C5C646400A8B60584BB8E9857236</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>E617E37B8DE4B930EC91E78E7B804A9C</string>
+				<string>2F824EA28F819F2E4A9E6D31E14D0603</string>
+				<string>98A22457F5E28CAF0B7E113A6D4142A1</string>
+				<string>901C95FA513F8BEC6992EE457A527DE1</string>
+				<string>539C2C0907CA46CC4DE78E19B1AFFA8E</string>
+				<string>F6A5E9881D67168D9B9BFA5FCD834596</string>
+				<string>EF305FCB32346C76431C1202E7AD467B</string>
+				<string>25BBDA674BE9447D354412C79BF4B16C</string>
+				<string>BC021CC978BE68B2BE0A690878FB54AF</string>
+				<string>41D47B37FDEA46945606C39C44042D8C</string>
+				<string>B87904014217EC9142A60100E6D363E3</string>
+				<string>DAC08D09C7E4411C8B01CD2FCFCD247B</string>
+				<string>6CBB0742821FD4D346404011AE148582</string>
+				<string>F280BEB32C116B6249D42E50A697B04B</string>
+				<string>26FDD94D57A937677D2A42E53E7DBD7A</string>
+				<string>DD7BED725086CF410512F736DE7AA95B</string>
+			</array>
+			<key>isa</key>
+			<string>PBXHeadersBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>F1F4E65611F5567A86AF797EAC3E225B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>4D12FAE56109712094DA78D38B05DA2C</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>COMPILER_FLAGS</key>
+				<string>-fno-objc-arc</string>
+			</dict>
+		</dict>
+		<key>F242671BEF9F47004BD4AEA6994ACB6B</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>GAIFields.h</string>
+			<key>path</key>
+			<string>Headers/Public/GAIFields.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F280BEB32C116B6249D42E50A697B04B</key>
+		<dict>
+			<key>fileRef</key>
+			<string>7ED4DAD1A4FB242A6CE917329C32BDCB</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>F2848ECE86915EED9032636E866D125F</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SPTSharedExampleGroups.m</string>
+			<key>path</key>
+			<string>Specta/Specta/SPTSharedExampleGroups.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F30A41276DE3EE0553B4749F788F4B8A</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>9E7AED6529044F5A3F1798885FA0EB66</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>ENABLE_STRICT_OBJC_MSGSEND</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>Target Support Files/Segment-GoogleAnalytics/Segment-GoogleAnalytics-prefix.pch</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>MTL_ENABLE_DEBUG_INFO</key>
+				<string>YES</string>
+				<key>OTHER_LDFLAGS</key>
+				<string></string>
+				<key>OTHER_LIBTOOLFLAGS</key>
+				<string></string>
+				<key>PRIVATE_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>PUBLIC_HEADERS_FOLDER_PATH</key>
+				<string></string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>SKIP_INSTALL</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>F3165B876D08CD102EA891025959EB19</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPDoubleTuple.m</string>
+			<key>path</key>
+			<string>Expecta/EXPDoubleTuple.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F39B31E5EECC1F9DF23BDFF4244FE860</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.script.sh</string>
+			<key>path</key>
+			<string>Pods-Segment-GoogleAnalytics_Tests-resources.sh</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F40B16934B552AC428855EC01D39473C</key>
+		<dict>
+			<key>fileRef</key>
+			<string>789F69996FFDE3AECA5AF9C317B256B6</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>F4CA468B5A9F8FF2A4DB8B236A8E71BF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>C4E98ABEAC39F16F3D1D5D53F15A2F9F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>F6A5E9881D67168D9B9BFA5FCD834596</key>
+		<dict>
+			<key>fileRef</key>
+			<string>97F182F971933BFEF29A646F7D22423E</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+			<key>settings</key>
+			<dict>
+				<key>ATTRIBUTES</key>
+				<array>
+					<string>Public</string>
+				</array>
+			</dict>
+		</dict>
+		<key>F711FE6DE60FD2ED5D589F9C3262A6F3</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>558A49FF40959AE7147F14C765269D33</string>
+				<string>CBFEA0C6D4EBA470E98B90635BAB38B2</string>
+				<string>2FC2FBF5CAFA206F9C92EC6A22AC0B84</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Support Files</string>
+			<key>path</key>
+			<string>../Target Support Files/Analytics</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F7DE9BBD243370BF8EFFF25D7E85CD4C</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>SEGGoogleAnalyticsIntegration.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>F8A3174F1370ED9A57F94C3ED212C70E</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>23C308732876898CC780DC4FD8A09F4C</string>
+				<string>5898D23317AA2AC18E0FD933409C5E9F</string>
+				<string>5DD6A636555E18CB2AEB2903355B1551</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>F9015232CB5F2A63DB560C88DCF86512</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>D41D8CD98F00B204E9800998ECF8427E</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>E703EF8141AB3D56D46182B4EA5FB571</string>
+			<key>remoteInfo</key>
+			<string>Analytics</string>
+		</dict>
+		<key>F9F824608D10EAF566AE7C2C9AD73CC5</key>
+		<dict>
+			<key>fileRef</key>
+			<string>279AA6492631DEFA8C439A9C088EEB8A</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>FAE4AA155A2514A44DCF02CDE86885CF</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+haveCountOf.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+haveCountOf.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>FB45FFD90572718D82AB9092B750F0CA</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_MODULES</key>
+				<string>YES</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_BOOL_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
+				<string>YES</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
+				<string>YES</string>
+				<key>CLANG_WARN_UNREACHABLE_CODE</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>YES</string>
+				<key>ENABLE_NS_ASSERTIONS</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>RELEASE=1</string>
+				</array>
+				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_FUNCTION</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>8.0</string>
+				<key>STRIP_INSTALLED_PRODUCT</key>
+				<string>NO</string>
+				<key>SYMROOT</key>
+				<string>${SRCROOT}/../build</string>
+				<key>VALIDATE_PRODUCT</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>FBBEEFC1F77A002E76A2E9CBC801BABF</key>
+		<dict>
+			<key>fileRef</key>
+			<string>E351727CD07BB90B2A3CAE2C2433F6C5</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>FCF10D4D8159FFF95CFCDB62577AA8E4</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>SEGPayload.m</string>
+			<key>path</key>
+			<string>Pod/Classes/Integrations/SEGPayload.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>FDF72740DBC37AFACFED73ED42282383</key>
+		<dict>
+			<key>fileRef</key>
+			<string>22F3505207F93C01E28757C157D01EEB</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>FE99B615AB863FEF83FD39F59E2A939D</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>name</key>
+			<string>EXPMatchers+raise.h</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+raise.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>FF44A189D47E0B1CB7FA13DE72A685BB</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>name</key>
+			<string>EXPMatchers+match.m</string>
+			<key>path</key>
+			<string>Expecta/Matchers/EXPMatchers+match.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+	</dict>
+	<key>rootObject</key>
+	<string>D41D8CD98F00B204E9800998ECF8427E</string>
+</dict>
+</plist>

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Segment-GoogleAnalytics.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Segment-GoogleAnalytics.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'F01830C0FF2E9E59A9ED6845'
+               BlueprintIdentifier = 'E3A74CCEAFDF61315433C6BD'
                BlueprintName = 'Segment-GoogleAnalytics'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'libSegment-GoogleAnalytics.a'>

--- a/Segment-GoogleAnalytics.podspec
+++ b/Segment-GoogleAnalytics.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
     idfa.dependency 'GoogleIDFASupport', '~> 3.14'
   end
 
-  s.supbspec 'Core' do |core|
+  s.subspec 'Core' do |core|
     # For users who don't want to bundle GoogleIDFASupport
     # If a user specified Segment-GoogleAnalytics/Core, we won't bundle IDFA
   end

--- a/Segment-GoogleAnalytics.podspec
+++ b/Segment-GoogleAnalytics.podspec
@@ -21,17 +21,17 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Pod/Classes/**/*'
 
-  s.default_subspec = 'NoIDFA'
-
   s.dependency 'Analytics', '~> 3.0.0'
   s.dependency 'GoogleAnalytics', '~> 3.14'
 
-  s.subspec 'NoIDFA' do |noidfa|
-  # subspec for users who don't want the IDFA Support
-  end
-
   s.subspec 'GoogleIDFASupport' do |idfa|
+    # This will get bundled unless a subspec is specified
     idfa.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -SEGMENT_IDFA' }
     idfa.dependency 'GoogleIDFASupport', '~> 3.14'
+  end
+
+  s.supbspec 'Core' do |core|
+  # For users who don't want to bundle GoogleIDFASupport
+  # If a user specified Segment-GoogleAnalytics/Core, we won't bundle IDFA
   end
 end

--- a/Segment-GoogleAnalytics.podspec
+++ b/Segment-GoogleAnalytics.podspec
@@ -21,7 +21,17 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Pod/Classes/**/*'
 
+  s.default_subspec = 'NoIDFA'
+
   s.dependency 'Analytics', '~> 3.0.0'
   s.dependency 'GoogleAnalytics', '~> 3.14'
-  s.dependency 'GoogleIDFASupport', '~> 3.14'
+
+  s.subspec 'NoIDFA' do |noidfa|
+  # subspec for users who don't want the IDFA Support
+  end
+
+  s.subspec 'GoogleIDFASupport' do |idfa|
+    idfa.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -SEGMENT_IDFA' }
+    idfa.dependency 'GoogleIDFASupport', '~> 3.14'
+  end
 end

--- a/Segment-GoogleAnalytics.podspec
+++ b/Segment-GoogleAnalytics.podspec
@@ -26,12 +26,11 @@ Pod::Spec.new do |s|
 
   s.subspec 'GoogleIDFASupport' do |idfa|
     # This will get bundled unless a subspec is specified
-    idfa.xcconfig = { 'OTHER_CFLAGS' => '$(inherited) -SEGMENT_IDFA' }
     idfa.dependency 'GoogleIDFASupport', '~> 3.14'
   end
 
   s.supbspec 'Core' do |core|
-  # For users who don't want to bundle GoogleIDFASupport
-  # If a user specified Segment-GoogleAnalytics/Core, we won't bundle IDFA
+    # For users who don't want to bundle GoogleIDFASupport
+    # If a user specified Segment-GoogleAnalytics/Core, we won't bundle IDFA
   end
 end


### PR DESCRIPTION
GoogleIDFASupport was causing issues for customers and making our GA pod unusable.
https://github.com/segmentio/analytics-ios/issues/442

This PR removes GoogleIDFASupport by default by creating two subspec's, one without, and one with GoogleIDFASupport. This also includes a preprocessor macro that can be used to conditionally enable IDFASupport within an app.
