### PR TITLE
Adds subspec for static library workaround

### DIFF
--- a/Segment-GoogleAnalytics.podspec
+++ b/Segment-GoogleAnalytics.podspec
@@ -22,7 +22,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Pod/Classes/**/*'
 
   s.dependency 'Analytics', '~> 3.0'
-  s.dependency 'GoogleAnalytics', '~> 3.14'
 
   s.subspec 'GoogleIDFASupport' do |idfa|
     # This will get bundled unless a subspec is specified
@@ -30,7 +29,15 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Core' do |core|
+    core.dependency 'GoogleAnalytics', '~> 3.14'
     # For users who don't want to bundle GoogleIDFASupport
     # If a user specified Segment-GoogleAnalytics/Core, we won't bundle IDFA
+  end
+
+  s.subspec 'StaticLibWorkaround' do |wordaround|
+    # For users who are unable to bundle static libraries as dependencies
+    # you can choose this subspec, but be sure to include the following in your Podfile:
+    # pod 'GoogleAnalytics'
+    # pod 'GoogleIDFASupport'  <- optional
   end
 end

--- a/Segment-GoogleAnalytics.podspec
+++ b/Segment-GoogleAnalytics.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
     # If a user specified Segment-GoogleAnalytics/Core, we won't bundle IDFA
   end
 
-  s.subspec 'StaticLibWorkaround' do |wordaround|
+  s.subspec 'StaticLibWorkaround' do |workaround|
     # For users who are unable to bundle static libraries as dependencies
     # you can choose this subspec, but be sure to include the following in your Podfile:
     # pod 'GoogleAnalytics'


### PR DESCRIPTION
Here's a suggested workaround for dealing with 

https://segment.com/docs/integrations/google-analytics/#target-has-transitive-dependencies-that-include-static-binaries

Still not ideal, but the thought is that we can continue to use Cocoapods to manage these dependencies making dependency updates easier.
