### PR TITLE
Map campaign data for Screen calls

### DIFF
--- a/Pod/Classes/SEGGoogleAnalyticsIntegration.m
+++ b/Pod/Classes/SEGGoogleAnalyticsIntegration.m
@@ -126,6 +126,28 @@
     SEGLog(@"[[[GAI sharedInstance] defaultTracker] set:%@ value:%@];", kGAIScreenName, payload.name);
 
     GAIDictionaryBuilder *hitBuilder = [GAIDictionaryBuilder createScreenView];
+    
+    NSDictionary *campaign = payload.properties[@"campaign"];
+    if ([campaign isKindOfClass:[NSDictionary class]]) {
+        if ([campaign[@"source"] isKindOfClass:[NSString class]]) {
+            [hitBuilder set:campaign[@"source"] forKey:kGAICampaignSource];
+        }
+        if ([campaign[@"name"] isKindOfClass:[NSString class]]) {
+            [hitBuilder set:campaign[@"name"] forKey:kGAICampaignName];
+        }
+        if ([campaign[@"content"] isKindOfClass:[NSString class]]) {
+            [hitBuilder set:campaign[@"content"] forKey:kGAICampaignContent];
+        }
+        if ([campaign[@"medium"] isKindOfClass:[NSString class]]) {
+            [hitBuilder set:campaign[@"medium"] forKey:kGAICampaignMedium];
+        }
+        // Segment does not currently spec the following keys that GA accepts
+        // kGAICampaignKeyword
+        // kGAICampaignId
+        // kGAICampaignAdNetworkClickId
+        // kGAICampaignAdNetworkId
+    }
+    
     NSDictionary *hit = [self setCustomDimensionsAndMetrics:payload.properties onHit:hitBuilder];
     [self.tracker send:hit];
     SEGLog(@"[[[GAI sharedInstance] defaultTracker] send:%@];", hit);

--- a/Pod/Classes/SEGGoogleAnalyticsIntegration.m
+++ b/Pod/Classes/SEGGoogleAnalyticsIntegration.m
@@ -87,11 +87,11 @@
 
 - (void)track:(SEGTrackPayload *)payload
 {
-    if ([payload.event isEqualToString: @"Order Completed"]) {
+    if ([payload.event isEqualToString:@"Order Completed"]) {
         [self orderCompleted:payload.properties];
         return;
     }
-    
+
     // Try to extract a "category" property.
     NSString *category = @"All"; // default
     NSString *categoryProperty = [payload.properties objectForKey:@"category"];
@@ -126,9 +126,9 @@
     SEGLog(@"[[[GAI sharedInstance] defaultTracker] set:%@ value:%@];", kGAIScreenName, payload.name);
 
     GAIDictionaryBuilder *hitBuilder = [GAIDictionaryBuilder createScreenView];
-    
+
     NSDictionary *hit = [self setCustomDimensionsAndMetricsAndCampaignData:payload.properties context:payload.context onHit:hitBuilder];
-        
+
     [self.tracker send:hit];
     SEGLog(@"[[[GAI sharedInstance] defaultTracker] send:%@];", hit);
 }
@@ -198,21 +198,21 @@
                 forKey:[GAIFields customMetricForIndex:metric]];
         }
     }
-    
+
     NSDictionary *campaign = context[@"campaign"];
     if ([campaign isKindOfClass:[NSDictionary class]]) {
         if ([campaign[@"source"] isKindOfClass:[NSString class]]) {
             [hit set:campaign[@"source"] forKey:kGAICampaignSource];
-        if ([campaign[@"name"] isKindOfClass:[NSString class]]) {
-            [hit set:campaign[@"name"] forKey:kGAICampaignName];
-        }
-        if ([campaign[@"content"] isKindOfClass:[NSString class]]) {
-            [hit set:campaign[@"content"] forKey:kGAICampaignContent];
-        }
-        if ([campaign[@"medium"] isKindOfClass:[NSString class]]) {
-            [hit set:campaign[@"medium"] forKey:kGAICampaignMedium];
-        }
-    } else {
+            if ([campaign[@"name"] isKindOfClass:[NSString class]]) {
+                [hit set:campaign[@"name"] forKey:kGAICampaignName];
+            }
+            if ([campaign[@"content"] isKindOfClass:[NSString class]]) {
+                [hit set:campaign[@"content"] forKey:kGAICampaignContent];
+            }
+            if ([campaign[@"medium"] isKindOfClass:[NSString class]]) {
+                [hit set:campaign[@"medium"] forKey:kGAICampaignMedium];
+            }
+        } else {
             // https://developers.google.com/analytics/devguides/collection/ios/v3/campaigns
             SEGLog(@"WARNING: campaign source is a required field for GA. Omitting campaign attributes");
         }

--- a/Pod/Classes/SEGGoogleAnalyticsIntegration.m
+++ b/Pod/Classes/SEGGoogleAnalyticsIntegration.m
@@ -115,7 +115,7 @@
                                                action:payload.event
                                                 label:label
                                                 value:value];
-    NSDictionary *hit = [self setCustomDimensionsAndMetrics:payload.properties onHit:hitBuilder];
+    NSDictionary *hit = [self setCustomDimensionsAndMetricsAndCampaignData:payload.properties context:payload.context onHit:hitBuilder];
     [self.tracker send:hit];
     SEGLog(@"[[[GAI sharedInstance] defaultTracker] send:%@];", hit);
 }
@@ -127,31 +127,8 @@
 
     GAIDictionaryBuilder *hitBuilder = [GAIDictionaryBuilder createScreenView];
     
-    NSDictionary *campaign = payload.context[@"campaign"];
-    if ([campaign isKindOfClass:[NSDictionary class]]) {
-        if ([campaign[@"source"] isKindOfClass:[NSString class]]) {
-            [hitBuilder set:campaign[@"source"] forKey:kGAICampaignSource];
-            if ([campaign[@"name"] isKindOfClass:[NSString class]]) {
-                [hitBuilder set:campaign[@"name"] forKey:kGAICampaignName];
-            }
-            if ([campaign[@"content"] isKindOfClass:[NSString class]]) {
-                [hitBuilder set:campaign[@"content"] forKey:kGAICampaignContent];
-            }
-            if ([campaign[@"medium"] isKindOfClass:[NSString class]]) {
-                [hitBuilder set:campaign[@"medium"] forKey:kGAICampaignMedium];
-            }
-        } else {
-            // https://developers.google.com/analytics/devguides/collection/ios/v3/campaigns
-            SEGLog(@"WARNING: campaign source is a required field for GA. Omitting campaign attributes");
-        }
-        // Segment does not currently spec the following keys that GA accepts
-        // kGAICampaignKeyword
-        // kGAICampaignId
-        // kGAICampaignAdNetworkClickId
-        // kGAICampaignAdNetworkId
-    }
-    
-    NSDictionary *hit = [self setCustomDimensionsAndMetrics:payload.properties onHit:hitBuilder];
+    NSDictionary *hit = [self setCustomDimensionsAndMetricsAndCampaignData:payload.properties context:payload.context onHit:hitBuilder];
+        
     [self.tracker send:hit];
     SEGLog(@"[[[GAI sharedInstance] defaultTracker] send:%@];", hit);
 }
@@ -201,7 +178,7 @@
 
 // event and screen properties are generall hit-scoped dimensions, so we want
 // to set them on the hits, not the tracker
-- (NSDictionary *)setCustomDimensionsAndMetrics:(NSDictionary *)properties onHit:(GAIDictionaryBuilder *)hit
+- (NSDictionary *)setCustomDimensionsAndMetricsAndCampaignData:(NSDictionary *)properties context:(NSDictionary *)context onHit:(GAIDictionaryBuilder *)hit
 {
     NSDictionary *customDimensions = self.settings[@"dimensions"];
     NSDictionary *customMetrics = self.settings[@"metrics"];
@@ -221,9 +198,34 @@
                 forKey:[GAIFields customMetricForIndex:metric]];
         }
     }
+    
+    NSDictionary *campaign = context[@"campaign"];
+    if ([campaign isKindOfClass:[NSDictionary class]]) {
+        if ([campaign[@"source"] isKindOfClass:[NSString class]]) {
+            [hit set:campaign[@"source"] forKey:kGAICampaignSource];
+        if ([campaign[@"name"] isKindOfClass:[NSString class]]) {
+            [hit set:campaign[@"name"] forKey:kGAICampaignName];
+        }
+        if ([campaign[@"content"] isKindOfClass:[NSString class]]) {
+            [hit set:campaign[@"content"] forKey:kGAICampaignContent];
+        }
+        if ([campaign[@"medium"] isKindOfClass:[NSString class]]) {
+            [hit set:campaign[@"medium"] forKey:kGAICampaignMedium];
+        }
+    } else {
+            // https://developers.google.com/analytics/devguides/collection/ios/v3/campaigns
+            SEGLog(@"WARNING: campaign source is a required field for GA. Omitting campaign attributes");
+        }
+        // Segment does not currently spec the following keys that GA accepts
+        // kGAICampaignKeyword
+        // kGAICampaignId
+        // kGAICampaignAdNetworkClickId
+        // kGAICampaignAdNetworkId
+    }
 
     return [hit build];
 }
+
 
 // e.g. extractNumber:"dimension3" from:[@"dimension" length] returns 3
 // e.g. extractNumber:"metric9" from:[@"metric" length] returns 9

--- a/Pod/Classes/SEGGoogleAnalyticsIntegration.m
+++ b/Pod/Classes/SEGGoogleAnalyticsIntegration.m
@@ -131,15 +131,18 @@
     if ([campaign isKindOfClass:[NSDictionary class]]) {
         if ([campaign[@"source"] isKindOfClass:[NSString class]]) {
             [hitBuilder set:campaign[@"source"] forKey:kGAICampaignSource];
-        }
-        if ([campaign[@"name"] isKindOfClass:[NSString class]]) {
-            [hitBuilder set:campaign[@"name"] forKey:kGAICampaignName];
-        }
-        if ([campaign[@"content"] isKindOfClass:[NSString class]]) {
-            [hitBuilder set:campaign[@"content"] forKey:kGAICampaignContent];
-        }
-        if ([campaign[@"medium"] isKindOfClass:[NSString class]]) {
-            [hitBuilder set:campaign[@"medium"] forKey:kGAICampaignMedium];
+            if ([campaign[@"name"] isKindOfClass:[NSString class]]) {
+                [hitBuilder set:campaign[@"name"] forKey:kGAICampaignName];
+            }
+            if ([campaign[@"content"] isKindOfClass:[NSString class]]) {
+                [hitBuilder set:campaign[@"content"] forKey:kGAICampaignContent];
+            }
+            if ([campaign[@"medium"] isKindOfClass:[NSString class]]) {
+                [hitBuilder set:campaign[@"medium"] forKey:kGAICampaignMedium];
+            }
+        } else {
+            // https://developers.google.com/analytics/devguides/collection/ios/v3/campaigns
+            SEGLog(@"WARNING: campaign source is a required field for GA. Omitting campaign attributes");
         }
         // Segment does not currently spec the following keys that GA accepts
         // kGAICampaignKeyword

--- a/Pod/Classes/SEGGoogleAnalyticsIntegration.m
+++ b/Pod/Classes/SEGGoogleAnalyticsIntegration.m
@@ -127,7 +127,7 @@
 
     GAIDictionaryBuilder *hitBuilder = [GAIDictionaryBuilder createScreenView];
     
-    NSDictionary *campaign = payload.properties[@"campaign"];
+    NSDictionary *campaign = payload.context[@"campaign"];
     if ([campaign isKindOfClass:[NSDictionary class]]) {
         if ([campaign[@"source"] isKindOfClass:[NSString class]]) {
             [hitBuilder set:campaign[@"source"] forKey:kGAICampaignSource];


### PR DESCRIPTION
cc @tiffanyzzhu29 @ladanazita @WesleyDRobinson  @myclamm 

Can you double check this is the expected behavior in our spec?

Mainly I want to know which segment fields should map to which GA fields. Also we will be mapping properties rather than context because that seems to be what props are intended for. Let me know if this is unexpected and if there's any reason customer might expect otherwise. 

https://segment.com/docs/spec/mobile/#campaign-related-events


