### PR TITLE
Remove static lib workaround 2

### DIFF
--- a/Segment-GoogleAnalytics.podspec
+++ b/Segment-GoogleAnalytics.podspec
@@ -44,11 +44,4 @@ Pod::Spec.new do |s|
     workaround.preserve_paths = 'Pod/Classes/**/*'
   end
 
-  s.subspec 'StaticLibWorkaround2' do |workaround2|
-    # For users who are unable to bundle static libraries as dependencies
-    # you can choose this subspec, but be sure to include the following in your Podfile:
-    # pod 'GoogleAnalytics'
-    # pod 'GoogleIDFASupport' <- optional
-    workaround2.source_files = 'Pod/Classes/**/*'
-  end
 end


### PR DESCRIPTION
The StaticLibWorkaround2 subspec does not include GA as a dependency,
however Cocoapods thinks it does. For this reason, this subspec blocks
future releases of the pod.