### PR TITLE
Add support for UTM campaign params from Deep Link Opened

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -6,13 +6,13 @@ PODS:
   - OCHamcrest (6.0.0)
   - OCMockito (4.0.1):
     - OCHamcrest (~> 6.0)
-  - Segment-GoogleAnalytics (1.1.7):
+  - Segment-GoogleAnalytics (1.2.0):
     - Analytics (~> 3.0)
-    - Segment-GoogleAnalytics/GoogleIDFASupport (= 1.1.7)
-  - Segment-GoogleAnalytics/Core (1.1.7):
+    - Segment-GoogleAnalytics/GoogleIDFASupport (= 1.2.0)
+  - Segment-GoogleAnalytics/Core (1.2.0):
     - Analytics (~> 3.0)
     - GoogleAnalytics (~> 3.14)
-  - Segment-GoogleAnalytics/GoogleIDFASupport (1.1.7):
+  - Segment-GoogleAnalytics/GoogleIDFASupport (1.2.0):
     - Analytics (~> 3.0)
     - GoogleIDFASupport (~> 3.14)
     - Segment-GoogleAnalytics/Core
@@ -24,9 +24,19 @@ DEPENDENCIES:
   - Segment-GoogleAnalytics (from `../`)
   - Specta
 
+SPEC REPOS:
+  trunk:
+    - Analytics
+    - Expecta
+    - GoogleAnalytics
+    - GoogleIDFASupport
+    - OCHamcrest
+    - OCMockito
+    - Specta
+
 EXTERNAL SOURCES:
   Segment-GoogleAnalytics:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
   Analytics: 0bf6c9302dcde2bdd9fc410ef2685ad8a1c804dd
@@ -35,9 +45,9 @@ SPEC CHECKSUMS:
   GoogleIDFASupport: aaf8c10bd429abb1c15349d5252244f5eda8ead1
   OCHamcrest: fc8ab38149b97df8db8029a3f2157c951bf9081d
   OCMockito: 62ddc6afff6a883f2864d51224b1dfdc0e9a7df7
-  Segment-GoogleAnalytics: e6b0708facfd5a6931449e9592feae7f335e8d4e
+  Segment-GoogleAnalytics: b5070619ad337eb09c4b01c52c3d0d90495307cf
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 
 PODFILE CHECKSUM: 6d601ae2b7ba92842b9a1f64636733b2cef01e31
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.8.4

--- a/Example/Segment-GoogleAnalytics/SEGAppDelegate.m
+++ b/Example/Segment-GoogleAnalytics/SEGAppDelegate.m
@@ -22,6 +22,9 @@
     [config use:[SEGGoogleAnalyticsIntegrationFactory instance]];
     [SEGAnalytics setupWithConfiguration:config];
     [[SEGAnalytics sharedAnalytics] track:@"Test Google Analytics"];
+    [[SEGAnalytics sharedAnalytics] track:@"Deep Link Opened" properties:@{
+        @"url": @"http://test-site.com/index.html?utm_campaign=wow&utm_source=source&gclid=something"
+    }];
     [[SEGAnalytics sharedAnalytics] flush];
     [SEGAnalytics debug:YES];
     return YES;

--- a/Pod/Classes/SEGGoogleAnalyticsIntegration.m
+++ b/Pod/Classes/SEGGoogleAnalyticsIntegration.m
@@ -197,7 +197,7 @@
             [hit set:[properties objectForKey:key]
                 forKey:[GAIFields customMetricForIndex:metric]];
         }
-        
+
     }
 
     NSDictionary *campaign = context[@"campaign"];
@@ -226,9 +226,9 @@
 
     if ([event isEqualToString:@"Deep Link Opened"]) {
         [hit setCampaignParametersFromUrl:[properties valueForKey:@"url"]];
-        SEGLog(@"[hit setCampaignParametersFromUril: %@]", [properties valueForKey:@"url"]);
+        SEGLog(@"[hit setCampaignParametersFromUrl: %@]", [properties valueForKey:@"url"]);
     }
-    
+
     return [hit build];
 }
 

--- a/Pod/Classes/SEGGoogleAnalyticsIntegration.m
+++ b/Pod/Classes/SEGGoogleAnalyticsIntegration.m
@@ -115,7 +115,7 @@
                                                action:payload.event
                                                 label:label
                                                 value:value];
-    NSDictionary *hit = [self setCustomDimensionsAndMetricsAndCampaignData:payload.properties context:payload.context onHit:hitBuilder];
+    NSDictionary *hit = [self setCustomDimensionsAndMetricsAndCampaignData:payload.properties context:payload.context event:payload.event onHit:hitBuilder];
     [self.tracker send:hit];
     SEGLog(@"[[[GAI sharedInstance] defaultTracker] send:%@];", hit);
 }
@@ -127,7 +127,7 @@
 
     GAIDictionaryBuilder *hitBuilder = [GAIDictionaryBuilder createScreenView];
 
-    NSDictionary *hit = [self setCustomDimensionsAndMetricsAndCampaignData:payload.properties context:payload.context onHit:hitBuilder];
+    NSDictionary *hit = [self setCustomDimensionsAndMetricsAndCampaignData:payload.properties context:payload.context event:payload.name onHit:hitBuilder];
 
     [self.tracker send:hit];
     SEGLog(@"[[[GAI sharedInstance] defaultTracker] send:%@];", hit);
@@ -178,7 +178,7 @@
 
 // event and screen properties are generall hit-scoped dimensions, so we want
 // to set them on the hits, not the tracker
-- (NSDictionary *)setCustomDimensionsAndMetricsAndCampaignData:(NSDictionary *)properties context:(NSDictionary *)context onHit:(GAIDictionaryBuilder *)hit
+- (NSDictionary *)setCustomDimensionsAndMetricsAndCampaignData:(NSDictionary *)properties context:(NSDictionary *)context  event:(NSString *)event onHit:(GAIDictionaryBuilder *)hit
 {
     NSDictionary *customDimensions = self.settings[@"dimensions"];
     NSDictionary *customMetrics = self.settings[@"metrics"];
@@ -197,6 +197,7 @@
             [hit set:[properties objectForKey:key]
                 forKey:[GAIFields customMetricForIndex:metric]];
         }
+        
     }
 
     NSDictionary *campaign = context[@"campaign"];
@@ -223,6 +224,11 @@
         // kGAICampaignAdNetworkId
     }
 
+    if ([event isEqualToString:@"Deep Link Opened"]) {
+        [hit setCampaignParametersFromUrl:[properties valueForKey:@"url"]];
+        SEGLog(@"[hit setCampaignParametersFromUril: %@]", [properties valueForKey:@"url"]);
+    }
+    
     return [hit build];
 }
 


### PR DESCRIPTION
Leverage the `@"url"` from `properties` which is present on a track "Deep Link Opened" event. https://github.com/segmentio/analytics-ios/blob/2a60383bf4269c1f5eae49ca2c90fe0b37777175/Analytics/Classes/SEGAnalytics.m#L374

Send the campaign parameters to Google Analytics using: `setCampaignParametersFromUrl`. Documentation here: https://developers.google.com/analytics/devguides/collection/ios/v3/reference/interface_g_a_i_dictionary_builder?hl=en#a58ad2b7a5a8279588214af3b94a2e60a

Verified this is working by firing "Deep Link Opened" track event with url `"http://test-site.com/index.html?utm_campaign=wow&utm_source=source&gclid=something"` and observing the following output in the Xcode debugging console: 
```
2020-01-08 12:17:38.137604-0800 Segment-GoogleAnalytics_Example[57524:6625108] [[[GAI sharedInstance] defaultTracker] send:{
    "&aclid" = "<null>";
    "&anid" = "<null>";
    "&cc" = "<null>";
    "&ci" = "<null>";
    "&ck" = "<null>";
    "&cm" = "<null>";
    "&cn" = wow;
    "&cs" = source;
    "&dclid" = "<null>";
    "&ea" = "Deep Link Opened";
    "&ec" = All;
    "&el" = "<null>";
    "&ev" = "<null>";
    "&gclid" = something;
    "&gmob_t" = "<null>";
    "&t" = event;
}];
```